### PR TITLE
Align CDR example with type description

### DIFF
--- a/mod_cdrs.md
+++ b/mod_cdrs.md
@@ -216,8 +216,8 @@ The *CDR* object describes the Charging Session and its costs. How these costs a
 				"standard": "IEC-62196-T2",
 				"format": "SOCKET",
 				"power_type": "AC_1_PHASE",
-				"voltage": "230",
-				"amperage": "64",
+				"voltage": 230,
+				"amperage": 64,
 				"tariff_id": "11"
 			}]
 		}
@@ -238,7 +238,7 @@ The *CDR* object describes the Charging Session and its costs. How these costs a
 		"start_date_time": "2015-06-29T21:39:09+02:00",
 		"dimensions": [{
 			"type": "TIME",
-			"volume": 1.973
+			"volume": "1.973"
 		}]
 	}],
 	"total_cost": "4,00",
@@ -247,7 +247,7 @@ The *CDR* object describes the Charging Session and its costs. How these costs a
 		"volume": "1.973"
 	}, {
 		"type": "ENERGY",
-		"volume": 15.342
+		"volume": "15.342"
 	}]
 }
 ```


### PR DESCRIPTION
Use integers to represent
  'location.evse.connectors.voltage' & 'location.evse.connectors.amperage'
  as defined in Connector type

Use decimal to represent 'volume' in
  'charging_periods.dimensions' & 'total_usage'
  as defined in CdrDimension type

----
*Side note* 
In 'total_usage', elements are defined as array items, which allows for repetition of same type elements. There is no comment on reasoning behind this and how anybody should interpret such cases. It may be valuable to turn 'total_usage' from array to object with dimension type being key and 'volume' with 'step_size' being values. For example instead of 
```
"total_usage": [{
	"type": "TIME",
	"volume": "1.973"
}, {
	"type": "ENERGY",
	"volume": "15.342"
}]
```
use 
```
"total_usage": {
	"TIME": {
		"volume": "1.973"
	}, 
	"ENERGY": {
		"volume": "15.342"
	}
}
```