### PR TITLE
Reverse CPO and eMSP parameters in the Token's PUT request URL

### DIFF
--- a/mod_tokens.md
+++ b/mod_tokens.md
@@ -105,8 +105,8 @@ The following parameters can be provided as URL segments.
 <div><!-- ---------------------------------------------------------------------------- --></div>
 | Parameter         | Datatype                              | Required | Description                                                                   |
 |-------------------|---------------------------------------|----------|-------------------------------------------------------------------------------|
-| country_code      | [string](types.md#16-string-type)(2)  | yes      | Country code of the CPO requesting this PUT to the eMSP system.               |
-| party_id          | [string](types.md#16-string-type)(3)  | yes      | Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.     |
+| country_code      | [string](types.md#16-string-type)(2)  | yes      | Country code of the eMSP sending this PUT request to the CPO system.               |
+| party_id          | [string](types.md#16-string-type)(3)  | yes      | Party ID (Provider ID) of the eMSP sending this PUT request to the CPO system.     |
 | token_uid         | [string](types.md#16-string-type)(15) | yes      | Token.uid of the (new) Token object (to replace).                             |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 

--- a/mod_tokens.md
+++ b/mod_tokens.md
@@ -66,8 +66,8 @@ The following parameters can be provided as URL segments.
 <div><!-- ---------------------------------------------------------------------------- --></div>
 | Parameter         | Datatype                              | Required | Description                                                                   |
 |-------------------|---------------------------------------|----------|-------------------------------------------------------------------------------|
-| country_code      | [string](types.md#16-string-type)(2)  | yes      | Country code of the CPO requesting this PUT to the eMSP system.               |
-| party_id          | [string](types.md#16-string-type)(3)  | yes      | Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.     |
+| country_code      | [string](types.md#16-string-type)(2)  | yes      | Country code of the eMSP requesting this GET from the CPO system.             |
+| party_id          | [string](types.md#16-string-type)(3)  | yes      | Party ID (Provider ID) of the eMSP requesting this GET from the CPO system.   |
 | token_uid         | [string](types.md#16-string-type)(15) | yes      | Token.uid of the Token object to retrieve.                                    |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 

--- a/transport_and_format.md
+++ b/transport_and_format.md
@@ -93,6 +93,10 @@ Example of a URL to a client owned object
 ```   
    https://www.server.com/ocpi/cpo/2.0/tariffs/NL/TNM/14
 ```   
+
+#### Errors
+When a client pushes a client owned object, but the {object-id} in the URL is different from the id in the object being pushed. A Server implementation is advised to return an [OCPI status code](transport_and_format.md): [2001](transport_and_format.md#2xxx-client-errors).
+
  
 
 ### Response format


### PR DESCRIPTION
This is a critical bug because it describes that the URL of a PUT request (something that the eMSP does) must contain the CPO's country_code and the CPO's party_id when it should be the eMSP's country_code and party_id respectively.