### PR TITLE
Clarify whose credentials we are sending

### DIFF
--- a/credentials.md
+++ b/credentials.md
@@ -37,7 +37,7 @@ This must return a `405 method not allowed` if the client was already registered
 
 Provides the server with updated credentials to access the client's system. This credentials object also contains extra information about the client such as its business details.
 
-A `PUT` will switch to the version that contains this credentials endpoint if it's different from the current version. The server must also fetch the client's endpoints again.
+A `PUT` will switch to the version that contains this credentials endpoint if it's different from the current version. The server must fetch the client's endpoints again, even if the version has not changed.
 
 If successful, the server must generate a new token for the client and respond with the client's updated credentials to access the server's system. The credentials object in the response also contains extra information about the server such as its business details.
 

--- a/credentials.md
+++ b/credentials.md
@@ -31,7 +31,7 @@ A `POST` initiates the registration process for this endpoint's version. The ser
 
 If successful, the server must generate a new token and respond with the client's new credentials to access the server's system. The credentials object in the response also contains extra information about the server such as its business details.
 
-This must return a `405 method not allowed` if the client was already registered.
+This must return a `HTTP status code 405: method not allowed` if the client was already registered.
 
 ### 1.3 __PUT__ Method
 
@@ -41,13 +41,14 @@ A `PUT` will switch to the version that contains this credentials endpoint if it
 
 If successful, the server must generate a new token for the client and respond with the client's updated credentials to access the server's system. The credentials object in the response also contains extra information about the server such as its business details.
 
-This must return a `405 method not allowed` if the client was not registered yet.
+This must return a `HTTP status code 405: method not allowed` if the client was not registered yet.
 
 ### 1.4 __DELETE__ Method
 
 Informs the server that its credentials to access the client's system are now invalid and can no longer be used. Both parties must end any automated communication. This is the unregistration process.
 
-This must return a `405 method not allowed` if the client was not registered.
+This must return a `HTTP status code 405: method not allowed` if the client was not registered.
+
 
 ## 2. Object description
 

--- a/credentials.md
+++ b/credentials.md
@@ -10,9 +10,9 @@ Example: `/ocpi/cpo/2.0/credentials` and `/ocpi/emsp/2.0/credentials`
 <div><!-- ---------------------------------------------------------------------------- --></div>
 | Method                      | Description                                                                                       |
 |-----------------------------|---------------------------------------------------------------------------------------------------|
-| [GET](#11-get-method)       | Retrieves the client's credentials for the server's platform.                                     |
-| [POST](#12-post-method)     | Provides the server with credentials to the client's system (i.e. register).                      |
-| [PUT](#13-put-method)       | Updates the server's credentials to the client's system.                                          |
+| [GET](#11-get-method)       | Retrieves the credentials object to access the server's platform.                                 |
+| [POST](#12-post-method)     | Provides the server with a credentials object to access the client's system (i.e. register).      |
+| [PUT](#13-put-method)       | Provides the server with an updated credentials object to access the client's system.             |
 | PATCH                       | n/a                                                                                               |
 | [DELETE](#14-delete-method) | Informs the server that its credentials to the client's system are now invalid (i.e. unregister). |
 <div><!-- ---------------------------------------------------------------------------- --></div>
@@ -20,27 +20,34 @@ Example: `/ocpi/cpo/2.0/credentials` and `/ocpi/emsp/2.0/credentials`
 
 ### 1.1 __GET__ Method
 
-Retrieves the client's credentials for the server's platform. The request body is empty, the response contains the credentials for the server's platform.
+Retrieves the credentials object to access the server's platform. The request body is empty, the response contains the credentials object to access the server's platform. This credentials object also contains extra information about the server such as its business details.
 
 
 ### 1.2 __POST__ Method
 
-Provides the server with credentials to the client's system, this initiates the registration process for this endpoint's version. The server must also fetch the client's endpoints for this version. 
+Provides the server with credentials to access the client's system. This credentials object also contains extra information about the client such as its business details.
 
-If successful, the server must generate a new token and respond with the client's new credentials to the server's system.
+A `POST` initiates the registration process for this endpoint's version. The server must also fetch the client's endpoints for this version.
 
+If successful, the server must generate a new token and respond with the client's new credentials to access the server's system. The credentials object in the response also contains extra information about the server such as its business details.
+
+This must return a `405 method not allowed` if the client was already registered.
 
 ### 1.3 __PUT__ Method
 
-Updates the server's credentials to the client's system and switches to the version that contains this credentials endpoint. The server must also fetch the client's endpoints again (for this version) as they could have been updated.
+Provides the server with updated credentials to access the client's system, This credentials object also contains extra information about the client such as its business details.
 
-If successful, the server must generate a new token for the client and respond with the client's updated credentials to the server's system.
+A `PUT` will switch to the version that contains this credentials endpoint if it's different from the current version. The server must also fetch the client's endpoints again.
 
+If successful, the server must generate a new token for the client and respond with the client's updated credentials to the server's system. The credentials object in the response also contains extra information about the server such as its business details.
+
+This must return a `405 method not allowed` if the client was not registered yet.
 
 ### 1.4 __DELETE__ Method
 
-Informs the server that its credentials to the client's system are now invalid and can no longer be used. Both parties must end any automated communication. This is the unregistration process.
+Informs the server that its credentials to access the client's system are now invalid and can no longer be used. Both parties must end any automated communication. This is the unregistration process.
 
+This must return a `405 method not allowed` if the client was not registered.
 
 ## 2. Object description
 

--- a/credentials.md
+++ b/credentials.md
@@ -35,11 +35,11 @@ This must return a `405 method not allowed` if the client was already registered
 
 ### 1.3 __PUT__ Method
 
-Provides the server with updated credentials to access the client's system, This credentials object also contains extra information about the client such as its business details.
+Provides the server with updated credentials to access the client's system. This credentials object also contains extra information about the client such as its business details.
 
 A `PUT` will switch to the version that contains this credentials endpoint if it's different from the current version. The server must also fetch the client's endpoints again.
 
-If successful, the server must generate a new token for the client and respond with the client's updated credentials to the server's system. The credentials object in the response also contains extra information about the server such as its business details.
+If successful, the server must generate a new token for the client and respond with the client's updated credentials to access the server's system. The credentials object in the response also contains extra information about the server such as its business details.
 
 This must return a `405 method not allowed` if the client was not registered yet.
 


### PR DESCRIPTION
Because using 'credentials for X' could mean:

- credentials that X needs to access your system
- credentials that you need to access X's system

So this is a fix to clarify that.