### PR TITLE
Extending `evse_uid` to string(48) match EVSE-IDs

### DIFF
--- a/mod_commands.md
+++ b/mod_commands.md
@@ -159,7 +159,7 @@ A reservation can be replaced/updated by sending a `RESERVE_NOW` request with th
 | expiry_date                  | [DateTime](types.md#12-datetime-type)  | 1     | The Date/Time when this reservation ends.                                                                                                       |
 | reservation_id               | int                                    | 1     | Reservation id, unique for this reservation. If the Charge Point allready has                                                                                                       |
 | location_id                  | [string](types.md#15-string-type)(15)  | 1     | Location.id of the Location (belonging to the CPO this request is send to) for which to reserve an EVSE.                                        |
-| evse_uid                     | [string](types.md#15-string-type)(15)  | ?     | Optional EVSE.uid of the EVSE of this Location if a specific EVSE has to be reserved.                                                           |
+| evse_uid                     | [string](types.md#15-string-type)(48)  | ?     | Optional EVSE.uid of the EVSE of this Location if a specific EVSE has to be reserved.                                                           |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
 
@@ -173,7 +173,7 @@ The `evse_uid` is optional. If no EVSE is specified, the Charge Point can itself
 | response_url             | [URL](types.md#16-url-type)            | 1     | URL that the CommandResponse POST should be sent to. This URL might contain an unique ID to be able to distinguish between StartSession requests. |
 | token                    | [Token](mod_tokens.md#32-token-object) | 1     | Token object the Charge Point has to use to start a new session.                                                                                  |
 | location_id              | [string](types.md#15-string-type)(15)  | 1     | Location.id of the Location (belonging to the CPO this request is send to) on which a session is to be started.                                   |
-| evse_uid                 | [string](types.md#15-string-type)(15)  | ?     | Optional EVSE.uid of the EVSE of this Location on which a session is to be started.                                                               |
+| evse_uid                 | [string](types.md#15-string-type)(48)  | ?     | Optional EVSE.uid of the EVSE of this Location on which a session is to be started.                                                               |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
 
@@ -195,7 +195,7 @@ The `evse_uid` is optional. If no EVSE is specified, the Charge Point can itself
 |--------------------------|----------------------------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | response_url             | [URL](types.md#16-url-type)            | 1     | URL that the CommandResponse POST should be sent to. This URL might contain an unique ID to be able to distinguish between UnlockConnector requests. |
 | location_id              | [string](types.md#15-string-type)(15)  | 1     | Location.id of the Location (belonging to the CPO this request is send to) of which it is requested to unlock the connector.                         |
-| evse_uid                 | [string](types.md#15-string-type)(15)  | 1     | EVSE.uid of the EVSE of this Location of which it is requested to unlock the connector.                                                              |
+| evse_uid                 | [string](types.md#15-string-type)(48)  | 1     | EVSE.uid of the EVSE of this Location of which it is requested to unlock the connector.                                                              |
 | connector_id             | [string](types.md#15-string-type)(15)  | 1     | Connector.id of the Connector of this Location of which it is requested to unlock.                                                                   |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 

--- a/mod_locations.md
+++ b/mod_locations.md
@@ -99,7 +99,7 @@ The following parameters can be provided as URL segments.
 | Parameter         | Datatype                              | Required | Description                                                                   |
 |-------------------|---------------------------------------|----------|-------------------------------------------------------------------------------|
 | location_id       | [string](types.md#15-string-type)(15) | yes      | Location.id of the Location object to retrieve.                               |
-| evse_uid          | [string](types.md#15-string-type)(15) | no       | Evse.uid, required when requesting an EVSE or Connector object.               |
+| evse_uid          | [string](types.md#15-string-type)(48) | no       | Evse.uid, required when requesting an EVSE or Connector object.               |
 | connector_id      | [string](types.md#15-string-type)(15) | no       | Connector.id, required when requesting a Connector object.                    |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
@@ -151,7 +151,7 @@ The following parameters can be provided as URL segments.
 | country_code      | [string](types.md#15-string-type)(2)  | yes      | Country code of the CPO requesting this PUT to the eMSP system.               |
 | party_id          | [string](types.md#15-string-type)(3)  | yes      | Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.     |
 | location_id       | [string](types.md#15-string-type)(15) | yes      | Location.id of the Location object to retrieve.                               |
-| evse_uid          | [string](types.md#15-string-type)(15) | no       | Evse.uid, required when requesting an EVSE or Connector object.               |
+| evse_uid          | [string](types.md#15-string-type)(48) | no       | Evse.uid, required when requesting an EVSE or Connector object.               |
 | connector_id      | [string](types.md#15-string-type)(15) | no       | Connector.id, required when requesting a Connector object.                    |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
@@ -184,7 +184,7 @@ This is an information push message, the objects pushed will not be owned by the
 | country_code      | [string](types.md#15-string-type)(2)  | yes      | Country code of the CPO requesting this PUT to the eMSP system.               |
 | party_id          | [string](types.md#15-string-type)(3)  | yes      | Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.     |
 | location_id       | [string](types.md#15-string-type)(15) | yes      | Location.id of the new Location object, or the Location of which an EVSE or Location object is send |
-| evse_uid          | [string](types.md#15-string-type)(15) | no       | Evse.uid, required when an EVSE or Connector object is send/replaced.         |
+| evse_uid          | [string](types.md#15-string-type)(48) | no       | Evse.uid, required when an EVSE or Connector object is send/replaced.         |
 | connector_id      | [string](types.md#15-string-type)(15) | no       | Connector.id, required when a Connector object is send/replaced.              |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 


### PR DESCRIPTION
To be able to use the protocol via a roaming platform, the `evse_uid`
should be the EVSE-ID as specified by eMI3. Therefor it has to be able
to contain a 48 character string.