### PR TITLE
update list of deps for mod_commands

### DIFF
--- a/mod_commands.md
+++ b/mod_commands.md
@@ -12,7 +12,7 @@ The following commands are supported:
 See [CommandType](#42-commandtype-enum) for a description of the different commands.
 _Use the `UNLOCK_CONNECTOR` command with care, please read the note at [CommandType](#42-commandtype-enum)._ 
 
-**Module dependency:** [Locations module](mod_locations.md#locations-module)
+**Module dependency:** [Locations module](mod_locations.md#locations-module), [Sessions module](mod_sessions.md#sessions-module)
 
 
 ## 1. Flow


### PR DESCRIPTION
Looking at the spec I see that the StopSession object needs a session ID, which the MSP can only receive and subsequently supply by implementing the MSP interface of the Session module.