### PR TITLE
Fix examples to be in line with the standard

### DIFF
--- a/mod_cdrs.md
+++ b/mod_cdrs.md
@@ -255,20 +255,20 @@ NOTE: The duration of charging (energy being transferred between EVSE and EV) du
 	"auth_method": "WHITELIST",
 	"location": {
 		"id": "LOC1",
-		"type": "on_street",
+		"type": "ON_STREET",
 		"name": "Gent Zuid",
 		"address": "F.Rooseveltlaan 3A",
 		"city": "Gent",
 		"postal_code": "9000",
 		"country": "BE",
 		"coordinates": {
-			"latitude": "3.72994",
-			"longitude": "51.04759"
+			"latitude": "3.729944",
+			"longitude": "51.047599"
 		},
 		"evses": [{
 			"uid": "3256",
 			"evse_id": "BE-BEC-E041503003",
-			"STATUS": "AVAILABLE",
+			"status": "AVAILABLE",
 			"connectors": [{
 				"id": "1",
 				"standard": "IEC_62196_T2",
@@ -293,8 +293,8 @@ NOTE: The duration of charging (energy being transferred between EVSE and EV) du
 				"price": "2.00",
 				"step_size": 300
 			}],
-			"last_updated": "2015-02-02T14:15:01Z"
-		}]
+		}],
+		"last_updated": "2015-02-02T14:15:01Z"
 	}],
 	"charging_periods": [{
 		"start_date_time": "2015-06-29T21:39:09Z",

--- a/mod_locations.md
+++ b/mod_locations.md
@@ -485,8 +485,8 @@ The *Location* object describes the location and its properties where a group of
 			"power_type": "AC_3_PHASE",
 			"voltage": 220,
 			"amperage": 16,
-			"tariff_id": "12"
-     		"last_updated": "2015-06-29T20:39:09Z"
+			"tariff_id": "12",
+			"last_updated": "2015-06-29T20:39:09Z"
 		}],
 		"physical_reference": "2",
 		"floor_level": "-2",

--- a/mod_locations.md
+++ b/mod_locations.md
@@ -438,12 +438,12 @@ The *Location* object describes the location and its properties where a group of
 	"postal_code": "9000",
 	"country": "BEL",
 	"coordinates": {
-		"latitude": "51.04759",
-		"longitude": "3.72994"
+		"latitude": "51.047599",
+		"longitude": "3.729944"
 	},
 	"evses": [{
         "uid": "3256",
-		"id": "BE-BEC-E041503001",
+		"evse_id": "BE-BEC-E041503001",
 		"status": "AVAILABLE",
 		"status_schedule": [],
 		"capabilities": [
@@ -473,20 +473,20 @@ The *Location* object describes the location and its properties where a group of
      	"last_updated": "2015-06-28T08:12:01Z"
 	}, {
         "uid": "3257",
-		"id": "BE-BEC-E041503002",
+		"evse_id": "BE-BEC-E041503002",
 		"status": "RESERVED",
 		"capabilities": [
 			"RESERVABLE"
 		],
 		"connectors": [{
 			"id": "1",
-			"status": "RESERVED",
 			"standard": "IEC_62196_T2",
 			"format": "SOCKET",
 			"power_type": "AC_3_PHASE",
 			"voltage": 220,
 			"amperage": 16,
 			"tariff_id": "12"
+     		"last_updated": "2015-06-29T20:39:09Z"
 		}],
 		"physical_reference": "2",
 		"floor_level": "-2",
@@ -733,7 +733,7 @@ _* These fields can be used to look-up energy qualification or to show it direct
 			{ "source": "NUCLEAR",        "percentage": 21.7 }
 		],
 	"environ_impact": [
-			{ "source": "NUCLEAR_WASTE",  "amount": 0.00006, },
+			{ "source": "NUCLEAR_WASTE",  "amount": 0.0006,  },
 			{ "source": "CARBON_DIOXIDE", "amount": 372,     }
 		],
 	"supplier_name":       "E.ON Energy Deutschland",
@@ -1033,14 +1033,14 @@ Operating on weekdays from 8am till 8pm with one exceptional opening on
     "twentyfourseven": false,
     "exceptional_openings": [
       {
-        "period_begin": "2014-06-21T09:00:00+02:00",
-        "period_end": "2014-06-21T12:00:00+02:00"
+        "period_begin": "2014-06-21T09:00:00Z",
+        "period_end": "2014-06-21T12:00:00Z"
       }
     ],
     "exceptional_closings": [
       {
-        "period_begin": "2014-06-24T00:00:00+02:00",
-        "period_end": "2014-06-25T00:00:00+02:00"
+        "period_begin": "2014-06-24T00:00:00Z",
+        "period_end": "2014-06-25T00:00:00Z"
       }
     ]
   }

--- a/mod_sessions.md
+++ b/mod_sessions.md
@@ -247,22 +247,23 @@ PATCH To URL: https://www.server.com/ocpi/cpo/2.0/sessions/NL/TNM/101
 	"start_datetime": "2015-06-29T22:39:09Z",
 	"kwh": 0.00,
 	"auth_id": "DE8ACC12E46L89",
+	"auth_method": "WHITELIST",
 	"location": {
 		"id": "LOC1",
-		"type": "on_street",
+		"type": "ON_STREET",
 		"name": "Gent Zuid",
 		"address": "F.Rooseveltlaan 3A",
 		"city": "Gent",
 		"postal_code": "9000",
 		"country": "BE",
 		"coordinates": {
-			"latitude": "3.72994",
-			"longitude": "51.04759"
+			"latitude": "3.729944",
+			"longitude": "51.047599"
 		},
 		"evses": [{
 			"uid": "3256",
 			"evse_id": "BE-BEC-E041503003",
-			"STATUS": "AVAILABLE",
+			"status": "AVAILABLE",
 			"connectors": [{
 				"id": "1",
 				"standard": "IEC_62196_T2",
@@ -330,17 +331,18 @@ PATCH To URL: https://www.server.com/ocpi/cpo/2.0/sessions/NL/TNM/101
 	"end_datetime": "2015-06-29T23:50:16Z",
 	"kwh": 41.00,
 	"auth_id": "DE8ACC12E46L89",
+	"auth_method": "WHITELIST",
 	"location": {
 		"id": "LOC1",
-		"type": "on_street",
+		"type": "ON_STREET",
 		"name": "Gent Zuid",
 		"address": "F.Rooseveltlaan 3A",
 		"city": "Gent",
 		"postal_code": "9000",
 		"country": "BE",
 		"coordinates": {
-			"latitude": "3.72994",
-			"longitude": "51.04759"
+			"latitude": "3.729944",
+			"longitude": "51.047599"
 		},
 		"evses": [{
 			"uid": "3256",
@@ -373,7 +375,7 @@ PATCH To URL: https://www.server.com/ocpi/cpo/2.0/sessions/NL/TNM/101
 	}, {
 		"start_date_time": "2015-06-29T22:40:54Z",
 		"dimensions": [{
-			"type": "energy",
+			"type": "ENERGY",
 			"volume": 41000
 		}, {
 			"type": "MIN_CURRENT",


### PR DESCRIPTION
Some of the examples used to explain the definitions of eg. Location or EVSE objects have some incorrect information (= not in line with the standard). I have located these them in the examples.  As suggested in #157, I have fixed these and created this pull request.

Some issues:
- Incorrect number of decimals (more than standard 4)
- Incorrect longitude or latitude (too few decimals according to regex definition)
- Keys in uppercase (all keys are defined in lowercase)
- Enum values in lowercase (all defined in uppercase)
- Incorrect keys used
- Use of non-UTC timestamps