### PR TITLE
Update `url` in Credentials Object Example to match spec

### DIFF
--- a/credentials.md
+++ b/credentials.md
@@ -93,7 +93,7 @@ The `party_id` and `country_code` give here, have no direct link with the eMI3 E
 
 ```json
 {
-    "url": "https://example.com/ocpi/cpo/",
+    "url": "https://example.com/ocpi/cpo/versions/",
     "token": "ebf3b399-779f-4497-9b9d-ac6ad3cc44d2",
     "party_id": "EXA",
     "country_code": "NL",


### PR DESCRIPTION
The description for the `url` field in a `Credentials` object reads _“The URL to your API versions endpoint.”_
The contained example following it shows `https://example.com/ocpi/cpo/` as a value for the `url` field.

When checking the documentation on the Versions Endpoint, it is always mounted on `https://…/versions`. This change updates the value of `url` to be in line to that part of the documentation.