### PR TITLE
EVSE's object "status" key in example should be lowercase

### DIFF
--- a/mod_sessions.md
+++ b/mod_sessions.md
@@ -347,7 +347,7 @@ PATCH To URL: https://www.server.com/ocpi/cpo/2.0/sessions/NL/TNM/101
 		"evses": [{
 			"uid": "3256",
 			"evse_id": "BE-BEC-E041503003",
-			"STATUS": "AVAILABLE",
+			"status": "AVAILABLE",
 			"connectors": [{
 				"id": "1",
 				"standard": "IEC_62196_T2",


### PR DESCRIPTION
I think there's an error in the "Simple Session example of a short finished session" on the sessions doc (https://github.com/ocpi/ocpi/blob/master/mod_sessions.md#31-session-object).
The "status" key in the EVSE object should be lowercase.