### PR TITLE
Command POST request and response should be CommandResponse type

### DIFF
--- a/mod_commands.md
+++ b/mod_commands.md
@@ -132,7 +132,7 @@ The response contains the direct response from the CPO, not the response from th
 
 | Datatype                                            | Card. | Description                                                              |
 |-----------------------------------------------------|-------|--------------------------------------------------------------------------|
-| [CommandResponseType](#41-commandresponsetype-enum) | 1     | Result of the command request, by the CPO (not the Charge Point). So this indicates if the CPO understood the command request and was able to send it to the Charge Point. This is not the response by the Charge Point |
+| [CommandResponse](#31-commandresponse-object)       | 1     | Result of the command request, by the CPO (not the Charge Point). So this indicates if the CPO understood the command request and was able to send it to the Charge Point. This is not the response by the Charge Point |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
 
@@ -189,7 +189,7 @@ Example:
 
 | Datatype                                            | Card. | Description                                                              |
 |-----------------------------------------------------|-------|--------------------------------------------------------------------------|
-| [CommandResponseType](#42-commandresponsetype-enum) | 1     | Result of the command request, from the Charge Point.         |
+| [CommandResponse](#31-commandresponse-object)       | 1     | Result of the command request, from the Charge Point.         |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
 


### PR DESCRIPTION
I think there's an error on the current request body and response body for the POST, which should be of type CommandResponse (an object like `{"result": "ACCEPTED"}` instead of type CommandResponseType, which is a simple string.