### PR TITLE
Added Get Object use case to Tariffs CPO interface

### DIFF
--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -49,7 +49,7 @@ Example endpoint structure: `/ocpi/cpo/2.0/tariffs/?date_from=xxx&amp;date_to=yy
 |===
 |Method |Description 
 
-|<<mod_tariffs_cpo_get_method,GET>> |Returns Tariff Objects from the CPO, last updated between the {date_from} and {date_to} (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>) 
+|<<mod_tariffs_cpo_get_method,GET>> |Returns Tariff Objects from the CPO, last updated between the {date_from} and {date_to} (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>), or get a specific Tariff.
 |POST |n/a 
 |PUT |n/a 
 |PATCH |n/a 
@@ -59,10 +59,10 @@ Example endpoint structure: `/ocpi/cpo/2.0/tariffs/?date_from=xxx&amp;date_to=yy
 [[mod_tariffs_cpo_get_method]]
 ===== *GET* Method
 
-Fetch information about all Tariffs.
+Depending on the URL segments provided, the GET request can either be used to retrieve information about a list of available Tariffs at this CPO: <<mod_tariffs_cpo_get_request_parameters,GET List>>; Or it can be used to get information about a specific Tariff: <<mod_tariffs_cpo_get_object_request_parameters,GET Object>>
 
 [[mod_tariffs_cpo_get_request_parameters]]
-====== Request Parameters
+====== GET List Request Parameters
 
 If additional parameters: {date_from} and/or {date_to} are provided, only Tariffs with (`last_updated`) between the given date_from and date_to will be returned.
 
@@ -79,7 +79,7 @@ This request is <<transport_and_format.asciidoc#transport_and_format_pagination,
 |===
 
 [[mod_tariffs_cpo_get_response_data]]
-====== Response Data
+====== GET List Response Data
 
 The endpoint returns an object with a list of valid Tariffs, the header will contain the <<transport_and_format.asciidoc#transport_and_format_paginated_response,pagination>> related headers.
 
@@ -91,6 +91,33 @@ Each object must contain all required fields. Fields that are not specified may 
 |Type |Card. |Description 
 
 |<<mod_tariffs_tariff_object,Tariff>> |* |List of all tariffs. 
+|===
+
+[[mod_tariffs_cpo_get_object_request_parameters]]
+====== GET Object Request Parameters
+
+Example endpoint structures for a specific Tariff:
+`/ocpi/cpo/2.0/tariffs/{tariff_id}`
+
+The following parameters can be provided as URL segments.
+
+[cols="3,2,1,10",options="header"]
+|===
+|Parameter |Datatype |Required |Description
+
+|tariff_id |<<types.asciidoc#types_string_type,string>>(36) |yes |Tariff.id of the Tariff object to retrieve.
+|===
+
+[[mod_tariffs_cpo_get_object_response_data]]
+====== GET Object Response Data
+
+The response contains the requested object.
+
+[cols="4,1,12",options="header"]
+|===
+|Type |Card. |Description
+
+|<<mod_tariffs_tariff_object,Tariff>> |1 |The Tariff object.
 |===
 
 [[mod_tariffs_emsp_interface]]


### PR DESCRIPTION
This patch proposes adding a Get Object use case (similar to Locations/EVSE/Connector) to get a specific Tariff.  The intent is to provide a simple means to insure data consistency between the end-user and the CPO in the case of communicating information that has financial impact (i.e. the Tariffs).

More specifically, the use case is:
1. User requests remote start on an EVSE from eMSP
2. eMSP calls CPO locations Get Object for up-to-date EVSE object
3. eMSP calls CPO tariffs Get Object for Tariff objects in EVSE
4. eMSP presents up-to-date EVSE and Tariff data to user
5. User confirms, etc

To attain the same data "freshness" without Get Object, either the eMSP and CPO must both implement PUSH, or the eMSP must poll the CPO for updated Tariffs at high frequency.

The other benefit is that a eMSP implementation can be simplified by removing the need to keep a local Tariff cache and maintaining its consistency.

These are both argument for adding Get Object to other modules (CDR, Sessions), but Tariffs seems most sensitive to data freshness because an inconsistent Tariff may lead to an end user being billed an unexpected amount.