### PR TITLE
Fix `energy_sources` example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,165 @@
+# Contributing
+
+When contributing to OCPI, please first discuss the change you wish to make via issue,
+email, slack, or any other method with the OCPI community.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+
+## Adding new features/functionality
+We strive to keep OCPI as free from IPR as possible. If you want to contribute by adding new functionality/features, 
+you are required to send us the signed Contributor License Agreement (CLA) document before contributing.
+To get the CLA, ask for it by send an e-mail to: [ocpi@nklnederland.nl](MAILTO:ocpi@nklnederland.nl).
+
+If you have send us the signed CLA, create a feature branch, 
+branching of from the development branch: `develop`
+
+Effort should be made to assure backward compatibility. If this is not possible, this should always be
+explicitly mentioned and provide upgrade path
+
+New modules should be designed to be used independently from other (existing) modules, when possible.
+
+New functionality/modules will take into account security and privacy.
+
+
+## Fixing bugs/typos
+Anybody (also without a signed Contributor License Agreement (CLA)) is welcome to fix an editorial issue, typo, improve example etc. 
+Please use Pull Requests for this.
+When fixing something in an existing version of OCPI, use the correct bug fix branch, for example: `release-2.1.1-bugfixes`.
+
+
+## Pull Request Process
+
+1. Ensure you have branched of from the correct branch, NEVER use `master`. 
+2. Create a pull request to the correct branch 
+3. Ask at least two other developers for a review.
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+
+## OCPI Specification release process
+
+If new functionality makes it into a new release is decided via a voting-procedure of companies/persons that signed the CLA.
+Request of a new functionality will be approved by a majority of at least 70% of the OCPI community who signed
+the CLA and took part in the voting-procedure.
+
+Request of a specific feature, to be used only in a specific context (i.e. for hubs, a specific region or country)
+will be approved by a minimum of 25% of the voters of OCPI community who signed the CLA and took part
+in the voting-procedure
+
+Releasing OCPI specifications shall only be done by the maintainers.
+
+All the development of a new OCPI version is done on the `develop` branch.
+We try to use feature branches as much as possible.
+
+When the OCPI community want to release a new OCPI version, this will be released from the `develop` branch.
+
+The new release will be merged into `master`. This way we ensure that `master` always contains the latest release. 
+
+At that moment also a new `release-*.*-bugfixes` branch will be created, which is to be used for fixing bugs/issues in the release version.
+The README.md will be update to point to this bug fix branch. 
+
+
+### OCPI Version numbering
+
+OCPI follows the following numbering scheme: `major.minor[.maintenance]`
+
+
+### OCPI Specification fix releases
+
+We always hope we never have to do this, but it might happen that we have to release a fixed version of OCPI, 
+because an error has slipped into the OCPI messages that cannot be fixed with documentation update only.
+In such a cause we will release a maintenance release: `*.*.1` etc, the original version then becomes deprecated, and should no longer be used.
+For example: to fix a couple of bugs in `OCPI 2.1`, we had to release `2.1.1`. 
+
+### OCPI Documentation update release process
+
+The OCPI community can decide to release an updated version of an OCPI protocol version. 
+For example: `2.0-d2` which contains a number of fixes in the documentation of `OCPI 2.0`, but no changes in the protocol.
+ 
+
+## Custom modules
+
+Any OCPI implementation is allowed to implement custom modules as specified by the documentation.
+
+If a company/contributor wants such a custom module to become part of a future version of OCPI 
+they have to create a pull request for new functionality as described above. 
+For this you also need to have signed the CLA.
+
+This new module has to go through the voting process.
+
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [ocpi@nklnederland.nl](MAILTO:ocpi@nklnederland.nl). 
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-This repository contains the OCPI specification.
+This repository contains the OCPI specification, latest release: OCPI 2.1.1.
 
+The branch with the latest fixes to the 2.1.1 documentation is [`release-2.1.1-bugfixes`](https://github.com/ocpi/ocpi/tree/release-2.1.1-bugfixes)
+
+The `master` branch always contains the latest official release.
+
+Development of the next version of OCPI, new functionality, is done in the  [`develop`](https://github.com/ocpi/ocpi/tree/develop) branch.
 
 ## Contents
 
@@ -30,6 +35,13 @@ Will be added lated:
 
 __Current versions:__
 
+Release 2.1.1:
+
+- Improvements from rel. 2.0
+- Chargepoint commands
+- realtime authorization
+- fixes some bugs of 2.1 (2.1 is now deprecated)
+
 Release 2.0: 
 
 - Charge Point Exchange Static & Dynamic (with tariffing covering only start/kWh/time)
@@ -37,13 +49,6 @@ Release 2.0:
 - Tariffing
 - Session Info exchange (cdr & ndr)
 - Registration (How to connect) & Security
-
-Release 2.1.1:
-
-- Improvements from rel. 2.0
-- Chargepoint commands
-- realtime authorization
-- fixes some bugs of 2.1 (2.1 is now deprecated)
 
 
 __Planned releases:__
@@ -57,4 +62,3 @@ Release 2.2:
 ----
 1 Dec 2014 [Draft v4](releases/old/OCPI-Draftv4.pdf) is published
 17 June 2015 [Draft v5] is moved to a new branch that will be used as a reference as the OCPI specifications are being redefined and the specifications are restructured in different files, a file per chapter
-

--- a/mod_locations.md
+++ b/mod_locations.md
@@ -729,12 +729,12 @@ _* These fields can be used to look-up energy qualification or to show it direct
 			{ "source": "GENERAL_GREEN",  "percentage": 35.9 },
 			{ "source": "GAS",            "percentage": 6.3  },
 			{ "source": "COAL",           "percentage": 33.2 },
-			{ "source": "GENERAL_FOSSIL", "percentage": 2.9, },
+			{ "source": "GENERAL_FOSSIL", "percentage": 2.9  },
 			{ "source": "NUCLEAR",        "percentage": 21.7 }
 		],
 	"environ_impact": [
-			{ "source": "NUCLEAR_WASTE",  "amount": 0.00006, },
-			{ "source": "CARBON_DIOXIDE", "amount": 372,     }
+			{ "source": "NUCLEAR_WASTE",  "amount": 0.00006  },
+			{ "source": "CARBON_DIOXIDE", "amount": 372      }
 		],
 	"supplier_name":       "E.ON Energy Deutschland",
 	"energy_product_name": "E.ON DirektStrom eco"


### PR DESCRIPTION
The example for `energy_sources` is not valid JSON as it contains some trailing commas. This PR removes those trailing commas.