### PR TITLE
A few documentation improvements

### DIFF
--- a/credentials.asciidoc
+++ b/credentials.asciidoc
@@ -4,9 +4,9 @@
 
 *Module Identifier: `credentials`*
 
-The credentials module is used the exchange the credentials token that has to be used by parties for authorization.
+The credentials module is used to exchange the credentials token that has to be used by parties for authorization of requests.
 
-Every OCPI request is required to contain a credentials token in a <<transport_and_format.asciidoc#transport_and_format_authorization_header,HTTP Authorization header>>.
+Every OCPI request is required to contain a credentials token in the <<transport_and_format.asciidoc#transport_and_format_authorization_header,HTTP Authorization header>>.
 
 
 [[credentials_use_cases]]
@@ -15,18 +15,18 @@ Every OCPI request is required to contain a credentials token in a <<transport_a
 [[credentials_registration]]
 ==== Registration
 
-To register a CPO in an eMSP platform (or vice versa), the CPO must create a unique credentials token that can be used for authenticating the eMSP.
-This credentials token along with the versions endpoint should be sent to the eMSP in a secure way that is outside the scope of this protocol.
+To register a CPO in an eMSP platform (or vice versa), the CPO must create a unique credentials token that can be used to authenticate the eMSP.
+This credentials token along with the versions endpoint SHOULD be sent to the eMSP in a secure way that is outside the scope of this protocol.
 
 `CREDENTIALS_TOKEN_A` is given offline, after registration store the `CREDENTIALS_TOKEN_C` which will be used in future exchanges.
 The `CREDENTIALS_TOKEN_A` can then be thrown away.
 
 The eMSP starts the registration process, retrieves the version information and details (using `CREDENTIALS_TOKEN_A` in the HTTP Authorization header).
-The eMSP generates `CREDENTIALS_TOKEN_B`, send it to the CPO in a POST request to the `credentials` module of the CPO.
+The eMSP generates `CREDENTIALS_TOKEN_B`, sends it to the CPO in a POST request to the `credentials` module of the CPO.
 The CPO stores `CREDENTIALS_TOKEN_B` and uses it for any requests to the eMSP, including the version information and details.
 
-(In the sequence diagrams below we use relative paths as short resource identifiers to illustrate a point;
-please note that they should really be absolute URLs in any working implementation of OCPI)
+(In the sequence diagrams below we use relative paths as short resource identifiers to illustrate API endpoints;
+please note that they should really be absolute URLs in any working implementation of OCPI.)
 
 .The OCPI registration process
 image::images/registration-sequence.svg[The OCPI registration process]
@@ -37,7 +37,7 @@ Due to its symmetric nature, the CPO and eMSP can be swapped in the registration
 [[credentials_updating_to_a_newer_version]]
 ==== Updating to a newer version
 
-At some point both parties will have implemented a newer OCPI version. To start using the newer version, one party has to send a PUT request to the credentials endpoint of the other party.
+At some point, both parties will have implemented a newer OCPI version. To start using the newer version, one party has to send a PUT request to the credentials endpoint of the other party.
 
 .The OCPI update process
 image::images/update-sequence.svg[The OCPI update process]
@@ -56,8 +56,8 @@ a PUT request to the credentials endpoint of the current version, similar to the
 [[credentials_errors_during_registration]]
 ==== Errors during registration
 
-When the Server connects back to the client during the credentials registration, it might encounter problems.
-When this happens, the Server should add the status code: <<status_codes.asciidoc#status_codes_3xxx_server_errors,3001>>
+When the server connects back to the client during the credentials registration, it might encounter problems.
+When this happens, the server should add the status code <<status_codes.asciidoc#status_codes_3xxx_server_errors,3001>>
 in the response to the POST from the client.
 
 [[credentials_required_endpoints_not_available]]
@@ -71,8 +71,8 @@ In case the client is starting the credentials exchange process and cannot find 
 it is expected NOT to send the POST request with credentials to the server.
 Log a message/notify the administrator to contact the administrator of the server system.
 
-In case the server, receiving the request from a client, cannot find the endpoints it expects,
-then it is expected to respond to the request with a status code: <<status_codes.asciidoc#status_codes_3xxx_server_errors,3003>>.
+In case the server receiving the request from a client cannot find the endpoints it expects,
+then it is expected to respond to the request with the status code <<status_codes.asciidoc#status_codes_3xxx_server_errors,3003>>.
 
 
 [[credentials_interfaces_and_endpoints]]
@@ -105,7 +105,7 @@ A `POST` initiates the registration process for this endpoint's version. The ser
 
 If successful, the server must generate a new credentials token and respond with the client's new credentials to access the server's system. The credentials object in the response also contains extra information about the server such as its business details.
 
-This must return a `HTTP status code 405: method not allowed` if the client was already registered.
+This method MUST return a `HTTP status code 405: method not allowed` if the client has already been registered before.
 
 [[credentials_put_method]]
 ==== *PUT* Method
@@ -116,14 +116,14 @@ A `PUT` will switch to the version that contains this credentials endpoint if it
 
 If successful, the server must generate a new credentials token for the client and respond with the client's updated credentials to access the server's system. The credentials object in the response also contains extra information about the server such as its business details.
 
-This must return a `HTTP status code 405: method not allowed` if the client was not registered yet.
+This method MUST return a `HTTP status code 405: method not allowed` if the client has not been registered yet.
 
 [[credentials_delete_method]]
 ==== *DELETE* Method
 
 Informs the server that its credentials to access the client's system are now invalid and can no longer be used. Both parties must end any automated communication. This is the unregistration process.
 
-This must return a `HTTP status code 405: method not allowed` if the client was not registered.
+This method MUST return a `HTTP status code 405: method not allowed` if the client has not been registered before.
 
 
 [[credentials_object_description]]
@@ -141,48 +141,47 @@ This must return a `HTTP status code 405: method not allowed` if the client was 
 |roles |<<credentials_credentials_role_class,CredentialsRole>> |+ |List of the roles this party provides.
 |===
 
-Every role needs a unique combination of: role, party_id and country_code.
+Every role needs a unique combination of: `role`, `party_id` and `country_code`.
 
-A party can have the some role more then once, for example when a CPO provides 'white label' services for virtual CPOs.
+A party can have the same role more than once, for example when a CPO provides 'white-label' services for virtual CPOs.
 
 One or more roles and thus `party_id` and `country_code` sets are provided here to inform a server about the `party_id` and `country_code`
 sets a client will use when pushing <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned objects>>.
-This helps a server determine the URLs a client will use when pushing
+This helps a server to determine the URLs a client will use when pushing
 a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>>.
 The `country_code` is added the make certain the URL used when pushing
-a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>> is unique,
-there might be multiple parties in the world with the same `party_id`, but the combination should always be unique.
+a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>> is unique as
+there might be multiple parties in the world with the same `party_id`. The combination of `country_id` and `party_id` should always be unique though.
 A party operating in multiple countries can always use the home country of the company for all connections.
 
-For example: an OCPI implementation might push EVSE IDs from a company for different countries,
-preventing an OCPI connection per country a company is operating in.
+For example: EVSE IDs can be pushed under the country and provider identification of a company, even if the EVSEs are actually located in a different country.
+This way it is not necessary to establish one OCPI connection per country a company operates in.
 
-The `party_id` and `country_code` give here, have no direct link with the eMI3 EVSE IDs and Contract IDs that might be used in the different OCPI modules.
-
-For example: an party implementing OCPI might push EVSE IDs with an eMI3 `spot operator` different from the OCPI `party_id` and/or the `country_code`.
+The `party_id` and `country_code` given here have no direct link with the eMI3 EVSE IDs and Contract IDs that might be used in the different OCPI modules.
+A party implementing OCPI MAY push EVSE IDs with an eMI3 `spot operator` different from the OCPI `party_id` and/or the `country_code`.
 
 [[credentials_example]]
 ==== Examples
 
-Example of a minimal CPO credentials object
+Example of a minimal CPO credentials object:
 [source,json]
 ----
 include::examples/credentials_example.json[]
 ----
 
-Example of a combined CPO/eMSP credentials object
+Example of a combined CPO/eMSP credentials object:
 [source,json]
 ----
 include::examples/credentials_example2.json[]
 ----
 
-Example of CPO credentials object with full business details
+Example of a CPO credentials object with full business details:
 [source,json]
 ----
 include::examples/credentials_example3.json[]
 ----
 
-Example of CPO credentials object with virtual CPOs
+Example of a CPO credentials object with virtual CPOs:
 [source,json]
 ----
 include::examples/credentials_example4.json[]
@@ -198,10 +197,10 @@ include::examples/credentials_example4.json[]
 |===
 |Property |Type |Card. |Description
 
-|role |<<credentials_credentials_role_enum,Role>> |1 |Type of Role.
-|business_details |<<mod_locations.asciidoc#mod_locations_businessdetails_class,BusinessDetails>> |1 |Details of this party.
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |1 |CPO, eMSP (or other role) ID of this party. (following the 15118 ISO standard).
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |1 |Country code of the country this party is operating in.
+|role |<<credentials_credentials_role_enum,Role>> |1 |Type of role
+|business_details |<<mod_locations.asciidoc#mod_locations_businessdetails_class,BusinessDetails>> |1 |Details of this party
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |1 |CPO, eMSP (or other role) ID of this party (following the ISO-15118 standard).
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |1 |ISO-3166 alpha-2 country code of the country this party is operating in.
 |===
 
 [[credentials_credentials_role_enum]]

--- a/credentials.asciidoc
+++ b/credentials.asciidoc
@@ -146,11 +146,11 @@ Every role needs a unique combination of: `role`, `party_id` and `country_code`.
 A party can have the same role more than once, for example when a CPO provides 'white-label' services for virtual CPOs.
 
 One or more roles and thus `party_id` and `country_code` sets are provided here to inform a server about the `party_id` and `country_code`
-sets a client will use when pushing <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned objects>>.
+sets a client will use when pushing <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Objects>>.
 This helps a server to determine the URLs a client will use when pushing
-a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>>.
+a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>>.
 The `country_code` is added the make certain the URL used when pushing
-a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>> is unique as
+a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>> is unique as
 there might be multiple parties in the world with the same `party_id`. The combination of `country_id` and `party_id` should always be unique though.
 A party operating in multiple countries can always use the home country of the company for all connections.
 

--- a/mod_cdrs.asciidoc
+++ b/mod_cdrs.asciidoc
@@ -335,12 +335,12 @@ include::examples/cdr_example.json[]
 |===
 |Value |Description 
 
-|ENERGY |Defined in kWh, default step size is 1 Wh
+|ENERGY |Defined in kWh, default step_size multiplier is 1 Wh
 |MAX_CURRENT |Maximum current reached during a charging session: defined in A (Ampere)
 |MIN_CURRENT |Minimum current reached during a charging session: defined in A (Ampere)
-|PARKING_TIME |Time not charging: defined in hours, default step size is 1 second
-|RESERVATION_TIME |Time charging station has been reserved and not yet been in use for this customer: defined in hours, default step size is 1 second
-|TIME |Time charging: defined in hours, default step size is 1 second
+|PARKING_TIME |Time not charging: defined in hours, default step_size multiplier is 1 second
+|RESERVATION_TIME |Time charging station has been reserved and not yet been in use for this customer: defined in hours, default step_size multiplier is 1 second
+|TIME |Time charging: defined in hours, default step_size multiplier is 1 second
 |===
 
 

--- a/mod_cdrs.asciidoc
+++ b/mod_cdrs.asciidoc
@@ -6,69 +6,68 @@
 
 *Data owner: `CPO`*
 
-A *Charge Detail Record* is the description of a concluded charging
-session. The CDR is the only billing-relevant object.
+A *Charge Detail Record* is the description of a concluded charging session. The CDR is the only billing-relevant object.
 CDRs are sent from the CPO to the eMSP after the charging session has ended.
-There is no requirement to send CDRs semi-realtime, it is seen as good practice to send them
-as soon as possible. But if there is an agreement between parties to send them for example once a month, that is also allowed by OCPI.
+Although there is no requirement to send CDRs in (semi-)realtime, it is seen as good practice to send them as soon as possible.
+But if there is an agreement between parties to send them, for example, once a month, that is also allowed by OCPI.
 
 [[mod_cdrs_flow_and_lifecycle]]
 === Flow and Lifecycle
 
-CDRs are created by the CPO. They probably only will be sent to the eMSP that will be paying the bill of a charging session.
-Because a CDR is for billing purposes, it cannot be changed/replaced, once sent to the eMSP, changes are not allowed in a CDR,
-a <<mod_cdrs_credit_cdrs,Credit CDR>> needs to be send.
+CDRs are created by the CPO. They most likely will be sent only to the eMSP that needs to pay the bill of the underlying charging session.
+Because a CDR is for billing purposes, it cannot be changed or replaced once sent to the eMSP. Changes are simply not allowed.
+Instead, a <<mod_cdrs_credit_cdrs,Credit CDR>> can be sent.
 
 [[mod_cdrs_credit_cdrs]]
 ==== Credit CDRs
 
-As CDRs are used for billing and can be seen as a kind of invoice. CDRs cannot be deleted, they have to be credited.
+As CDRs are used for billing and can be seen as a kind of invoice, they cannot be deleted. Instead, they have to be credited.
 
-When a CPO wants to make changes to a CDR that is already send the a CPO, the CPO has to send a credit CDR for
-the first CDR. This credit CDR SHALL have a different CDR.id, this can be a completely different number,
-or it can be the id of the original CDR with something appended like for example: "-C" to make it unique again.
-To indicate this is a Credit CDR, the <<mod_cdrs_cdr_object,`credit`>> field is set to `true`
+When a CPO wants to make changes to a CDR that was already sent to the eMSP, the CPO has to send a Credit CDR for the first CDR.
+This credit CDR SHALL have a different CDR.id which can be a completely different number,
+or it can be the id of the original CDR with something appended like for example: `-C` to make it unique again.
+To indicate that a CDR is a Credit CDR, the <<mod_cdrs_cdr_object,`credit`>> field has to be set to `true`.
 The Credit CDR references the old CDR via the <<mod_cdrs_cdr_object,`credit_reference_id`>> field,
 which SHALL contain the <<mod_cdrs_cdr_object,`id`>> of the original CDR.
 The Credit CDR will contain all the data of the original CDR.
 Only the values in the <<mod_cdrs_cdr_object,`total_cost`>> field SHALL contain the negative amounts of the original CDR.
 
-After having send the Credit CDR, the CPO can send a new CDR, with a new unique ID,
-with the fields: <<mod_cdrs_cdr_object,`credit`>> and <<mod_cdrs_cdr_object,`credit_reference_id`>> omitted.
+After having sent the Credit CDR, the CPO can send a new CDR with a new unique ID
+and the fields: <<mod_cdrs_cdr_object,`credit`>> and <<mod_cdrs_cdr_object,`credit_reference_id`>> omitted.
 
-NOTE: How far back in time a CPO can send a credit CDR, is not defined by OCPI,
-that is up the business contracts between the different parties involved,
-there might be local laws involved etc.
+NOTE: How far back in time a CPO can send a Credit CDR is not defined by OCPI.
+It is up the business contracts between the different parties involved, as there might be local laws involved etc.
 
 
 [[mod_cdrs_push_model]]
 ==== Push model
 
-When the CPO creates CDR(s) they push them to the relevant eMSP by calling <<mod_cdrs_post_method,POST>> on the eMSPs CDRs endpoint with the newly created CDR(s). A CPO is not required to send ALL CDRs to ALL eMSPs, it is allowed to only send CDRs to the eMSP that a CDR is relevant to.
+When the CPO creates CDR(s) they push them to the relevant eMSP by calling <<mod_cdrs_post_method,POST>> on the eMSPs CDRs endpoint with the newly created CDR(s). A CPO is not required to send _all_ CDRs to _all_ eMSPs, it is allowed to only send CDRs to the eMSP that a CDR is relevant to.
 
-CDRs should contain enough information (dimensions) to allow the eMSP to validate the total costs.
-It is advised to send enough information to the eMSP so it can calculate its own costs for billing their customer. An eMSP might have a very different contract/pricing model with the EV driver than the tariff structure from the CPO.
+CDRs should contain enough information (dimensions) to allow the eMSP to validate the total cost.
+It is advised to send enough information to the eMSP so that they can calculate their own costs for billing their customers.
+An eMSP might have a very different contract/pricing model with their EV drivers than the tariff structure of the CPO.
 
 _NOTE: CDRs can not yet be updated or removed. This might be added in a future version of OCPI._
 
-If the CPO, for any reason wants to view a CDR it has posted to a eMSP system, the CPO can retrieve the CDR by calling the <<mod_cdrs_msp_get_method,GET>> on the eMSPs CDRs endpoint at the URL returned in the response to the <<mod_cdrs_post_method,POST>>.
+If the CPO, for any reason, wants to view a CDR it has posted to an eMSP's system, the CPO can retrieve the CDR by performing a <<mod_cdrs_msp_get_method,GET>> request on the eMSP's CDRs endpoint at the URL returned in the response to the <<mod_cdrs_post_method,POST>>.
 
 [[mod_cdrs_pull_model]]
 ==== Pull model
 
-eMSPs who do not support the push model need to call
-<<mod_cdrs_cpo_get_method,GET>> on the CPOs CDRs endpoint to receive a list of CDRs.
+eMSPs who do not support the Push model need to call
+<<mod_cdrs_cpo_get_method,GET>> on the CPO's CDRs endpoint to receive a list of CDRs.
 
-This <<mod_cdrs_cpo_get_method,GET>> can also be used, combined with the Push model to retrieve CDRs, after the system (re)connects to a CPO, to get a list of CDRs, 'missed' during a time offline.
+This <<mod_cdrs_cpo_get_method,GET>> can also be used in combination with the Push model to retrieve CDRs after the system (re-)connects to a CPO, to get a list of CDRs _missed_ during a downtime of the eMSP's system.
 
 A CPO is not required to return all known CDRs, the CPO is allowed to return only the CDRs that are relevant for the requesting eMSP.
 
 [[mod_cdrs_interfaces_and_endpoints]]
-=== Interfaces and endpoints
+=== Interfaces and Endpoints
 
-There is both a CPO and an eMSP interface for CDRs. Depending on business requirements parties can decide to use
-the CPO Interface/Get model, or the eMSP Interface/Push model, or both.
-Push is the preferred model to use, the eMSP will receive CDRs when created by the CPO.
+There are both, a CPO and an eMSP interface for CDRs. Depending on business requirements, parties can decide to use
+the CPO Interface (Pull model), or the eMSP Interface (Push model), or both.
+Push is the preferred model to use, because the eMSP will receive CDRs in semi-realtime when they are created by the CPO.
 
 [[mod_cdrs_cpo_interface]]
 ==== CPO Interface
@@ -77,15 +76,15 @@ The CDRs endpoint can be used to create or retrieve CDRs.
 
 Endpoint structure definition:
 
-`{cdr_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&[offset={offset}]&[limit={limit}]`
+`{cdr_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&amp;[offset={offset}]&amp;[limit={limit}]`
 
 Examples:
 
-`+https://www.server.com/ocpi/cpo/2.2/cdrs/?date_from=2019-01-28T12:00:00&date_to=2019-01-29T12:00:00+`
+`+https://www.server.com/ocpi/cpo/2.2/cdrs/?date_from=2019-01-28T12:00:00&amp;date_to=2019-01-29T12:00:00+`
 
 `+https://ocpi.server.com/2.2/cdrs/?offset=50+`
 
-`+https://www.server.com/ocpi/2.2/cdrs/?date_from=2019-01-29T12:00:00&limit=100+`
+`+https://www.server.com/ocpi/2.2/cdrs/?date_from=2019-01-29T12:00:00&amp;limit=100+`
 
 `+https://www.server.com/ocpi/cpo/2.2/cdrs/?offset=50&amp;limit=100+`
 
@@ -94,7 +93,7 @@ Examples:
 |===
 |Method |Description 
 
-|<<mod_cdrs_cpo_get_method,GET>> |Fetch CDRs, last updated (which in the current version of OCPI can only be the creation date/time) between the {date_from} and {date_to} (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>) 
+|<<mod_cdrs_cpo_get_method,GET>> |Fetch CDRs last updated (which in the current version of OCPI can only be the creation Date/Time) between the `{date_from}` and `{date_to}` (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>). 
 |POST |n/a 
 |PUT |n/a 
 |PATCH |n/a 
@@ -104,12 +103,12 @@ Examples:
 [[mod_cdrs_cpo_get_method]]
 ===== *GET* Method
 
-Fetch CDRs from the CPO systems. 
+Fetch CDRs from the CPO's system.
 
 [[mod_cdrs_request_parameters]]
 ====== Request Parameters
 
-If additional parameters: {date_from} and/or {date_to} are provided, only CDRs with `last_updated` between the given date_from and date_to will be returned.
+If additional parameters: `{date_from}` and/or `{date_to}` are provided, only CDRs with `last_updated` between the given `date_from` and `date_to` will be returned.
 
 This request is <<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>, it supports the <<transport_and_format.asciidoc#transport_and_format_paginated_request,pagination>> related URL parameters.
 
@@ -128,7 +127,7 @@ This request is <<transport_and_format.asciidoc#transport_and_format_pagination,
 
 The endpoint returns a list of CDRs matching the given parameters in the GET request, the header will contain the <<transport_and_format.asciidoc#transport_and_format_paginated_response,pagination>> related headers. 
 
-Any older information that is not specified in the response is considered as no longer valid.
+Any older information that is not specified in the response is considered no longer valid.
 Each object must contain all required fields. Fields that are not specified may be considered as null values.
 
 |===
@@ -140,13 +139,13 @@ Each object must contain all required fields. Fields that are not specified may 
 [[mod_cdrs_emsp_interface]]
 ==== eMSP Interface
 
-The CDRs endpoint can be used to create, or get CDRs.
+The CDRs endpoint can be used to create and retrieve CDRs.
 
 [cols="2,12",options="header"]
 |===
 |Method |Description 
 
-|<<mod_cdrs_msp_get_method,GET>> |Retrieve an existing CDR 
+|<<mod_cdrs_msp_get_method,GET>> |Retrieve an existing CDR.
 |<<mod_cdrs_post_method,POST>> |Send a new CDR. 
 |PUT |n/a (CDRs cannot be replaced) 
 |PATCH |n/a (CDRs cannot be updated) 
@@ -156,12 +155,12 @@ The CDRs endpoint can be used to create, or get CDRs.
 [[mod_cdrs_msp_get_method]]
 ===== GET Method
 
-Fetch CDRs from the eMSP system. 
+Fetch CDRs from the eMSP's system. 
 
 Endpoint structure definition:
 
 No structure defined. This is open to the eMSP to define, the URL is provided to the CPO by the eMSP in the result of the POST request.
-Therefor OCPI does not define variables.
+Therefore, OCPI does not define variables.
 
 Example:
 
@@ -171,12 +170,12 @@ Example:
 [[mod_cdrs_response_url]]
 ====== Response URL
 
-To retrieve an existing URL from the eMSP system, the URL, returned in the response to a POST of a new CDR, has to be used.
+To retrieve an existing URL from the eMSP's system, the URL, returned in the response to a POST of a new CDR, has to be used.
 
 [[mod_cdrs_msp_get_response_data]]
 ====== Response Data
 
-The endpoint returns the requested CDR, if it exists
+The endpoint returns the requested CDR, if it exists.
 
 |===
 |Datatype |Card. |Description 
@@ -189,7 +188,7 @@ The endpoint returns the requested CDR, if it exists
 
 Creates a new CDR.
 
-The post method should contain the full, final CDR object.
+The POST method should contain the full and final CDR object.
 
 Endpoint structure definition:
 
@@ -204,7 +203,7 @@ Example:
 [[mod_cdrs_request_body]]
 ====== Request Body
 
-In the post request the new CDR object is sent.
+In the POST request the new CDR object is sent.
 
 [cols="4,1,12",options="header"]
 |===
@@ -216,13 +215,13 @@ In the post request the new CDR object is sent.
 [[mod_cdrs_response_headers]]
 ====== Response Headers
 
-The response should contain the URL to the just created CDR object in the eMSP system.
+The response should contain the URL to the just created CDR object in the eMSP's system.
 
 [cols="3,2,1,10",options="header"]
 |===
 |Parameter |Datatype |Required |Description 
 
-|Location |<<types.asciidoc#types_url_type,URL>> |yes |URL to the newly created CDR in the eMSP system, can be used by the CPO system to do a GET on of the same CDR 
+|Location |<<types.asciidoc#types_url_type,URL>> |yes |URL to the newly created CDR in the eMSP's system, can be used by the CPO system to perform a GET on the same CDR. 
 |===
 
 The eMSP returns the URL where the newly created CDR can be found. OCPI does not define a specific structure for this URL.
@@ -237,64 +236,63 @@ Example:
 [[mod_cdrs_cdr_object]]
 ==== _CDR_ Object
 
-The _CDR_ object describes the Charging Session and its costs, how these costs are built up, etc.
+The _CDR_ object describes the charging session and its costs, how these costs are composed, etc.
 
 The CDR object is different from the <<mod_sessions.asciidoc#mod_sessions_session_object,Session>> object.
 The <<mod_sessions.asciidoc#mod_sessions_session_object,Session>> object is dynamic as it reflects the current state of the charging session.
 The information is meant to be viewed by the driver while the charging session is ongoing.
 
-The CDR on the other hand can be thought of as "sealed",
+The CDR on the other hand can be thought of as _sealed_,
 preserving the information valid at the moment in time the underlying session was started.
 This is a requirement of the main use case for CDRs, namely invoicing.
 If e.g. a street is renamed the day after a session took place, the driver should be presented with the name valid at the time the session was started.
-This guarantees that CDR will be recognized as correct by the driver and not contested.
+This guarantees that the CDR will be recognized as correct by the driver and is not going to be contested.
 
-The _CDR_ object shall always contain information like location, EVSE, Tariffs and Token as they were at the START of the Charging Session.
+The _CDR_ object shall always contain information like Location, EVSE, Tariffs and Token as they were *at the start* of the charging session.
 
-A CPO SHALL at least start (and add) a ChargingPeriod every moment/event that has relevance for the total cost of this CDR.
-During a charging session, different parameters change all the time, like the amount of ENERGY used, or the time of day.
-These changes can result in another TariffElement of the Tariff becoming active.
-When another TariffElement becomes active,
-the CPO SHALL add a new ChargingPeriod with at least all the relevant information for the change to the other TariffElement.
-The CPO is allowed to add more "in-between" ChargingPeriods to a CDR then these required ChargingPeriods.
-Examples of extra "in-between" ChargingPeriods:
+A CPO SHALL at least start (and add) a `ChargingPeriod` every moment/event that has relevance for the total costs of a CDR.
+During a charging session, different parameters change all the time, like the amount of energy used, or the time of day.
+These changes can result in another Tariff Element of the Tariff becoming active.
+When another Tariff Element becomes active,
+the CPO SHALL add a new Charging Period with at least all the relevant information for the change to the other Tariff Element.
+The CPO is allowed to add more _in-between_ Charging Periods to a CDR though. Examples of additional Charging Periods:
 
-- When an ENERGY based Tariff changes in price after 17:00. The CPO SHALL start a new ChargingPeriod at 17:00,
-which contains at least the ENERGY in kWh consumed until 17:00.
-- When the price of a Tariff is higher when the EV is charging faster than  32A,
-a new ChargingPeriod SHALL be added the moment the Charging goes over 32A. This may be a moment that is calculated by the CPO,
-as the Charge Point might not send the information to the CPO,
-but it can be interpolated by the CPO by using the metering information before and after that moment.
+- When an energy based Tariff changes in price after 17:00. The CPO SHALL start a new Charging Period at 17:00,
+which contains at least the energy in kWh consumed until 17:00.
+- When the price of a Tariff is higher when the EV is charging faster than 32A,
+a new Charging Period SHALL be added the moment the charging power goes over 32A.
+This may be a moment that is calculated by the CPO, as the Charge Point might not send the information to the CPO,
+but it can be interpolated by the CPO using the metering information before and after that moment.
 
 [cols="3,3,1,10",options="header"]
 |===
 |Property |Type |Card. |Description 
 
-|id |<<types.asciidoc#types_cistring_type,CiString>>(39) |1 |Uniquely identifies the CDR within the CPOs platform (and sub-operator platforms). This field is longer then the usual 36 chars to allow for credit CDRs to have <<mod_cdrs_credit_cdrs,something appended>> to the original ID, to make it unique. Normal (non-credit) CDRs SHALL only have an ID with a maximum length of 36.
+|id |<<types.asciidoc#types_cistring_type,CiString>>(39) |1 |Uniquely identifies the CDR within the CPO's platform (and suboperator platforms). This field is longer than the usual 36 characters to allow for credit CDRs to have <<mod_cdrs_credit_cdrs,something appended>> to the original ID. Normal (non-credit) CDRs SHALL only have an ID with a maximum length of 36.
 |start_date_time |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Start timestamp of the charging session. 
 |stop_date_time |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Stop timestamp of the charging session. 
-|session_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |? |Unique ID of the Session for which this CDR is send. Is only allowed to be omitted when the CPO has not implemented the Sessions Module. 
-|cdr_token |<<mod_cdrs_cdr_token_object,CdrToken>> |1 |Token used to start this Charging Session, includes all the relevant information to identify the unique token.
+|session_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |? |Unique ID of the Session for which this CDR is sent. Is only allowed to be omitted when the CPO has not implemented the Sessions module. 
+|cdr_token |<<mod_cdrs_cdr_token_object,CdrToken>> |1 |Token used to start this charging session, includes all the relevant information to identify the unique token.
 |auth_method |<<mod_cdrs_authmethod_enum,AuthMethod>> |1 |Method used for authentication. 
 |cdr_location |<<mod_cdrs_cdr_location_class,CdrLocation>> |1 |Location where the charging session took place, including only the relevant <<mod_locations.asciidoc#mod_locations_evse_object,EVSE>> and <<mod_locations.asciidoc#mod_locations_connector_object,Connector>>.
 |meter_id |<<types.asciidoc#types_string_type,string>>(255) |? |Identification of the Meter inside the Charge Point.
 |currency |<<types.asciidoc#types_string_type,string>>(3) |1 |Currency of the CDR in ISO 4217 Code. 
-|tariffs |<<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariff>> |* |List of relevant tariff elements, see: <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariff>>. When relevant, a "Free of Charge" tariff should also be in this list, and point to a defined "Free of Charge" tariff. 
-|charging_periods |<<mod_cdrs_chargingperiod_class,ChargingPeriod>> |+ |List of charging periods that make up this charging session. A session consists of 1 or more periods, where each period has a different relevant Tariff. 
+|tariffs |<<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariff>> |* |List of relevant Tariff Elements, see: <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariff>>. When relevant, a _Free of Charge_ tariff should also be in this list, and point to a defined _Free of Charge_ Tariff. 
+|charging_periods |<<mod_cdrs_chargingperiod_class,ChargingPeriod>> |+ |List of Charging Periods that make up this charging session. A session consists of 1 or more periods, where each period has a different relevant Tariff. 
 |total_cost |<<types.asciidoc#types_price_class,Price>> |1 |Total cost of this transaction in the specified currency.
 |total_energy |<<types.asciidoc#types_number_type,number>> |1 |Total energy charged, in kWh.
-|total_time |<<types.asciidoc#types_number_type,number>> |1 |total duration of this session (including the duration of charging and not charging), in hours. 
-|total_parking_time |<<types.asciidoc#types_number_type,number>> |? |Total duration during this session that the EV is not being charged (no energy being transfered between EVSE and EV), in hours. 
-|remark |<<types.asciidoc#types_string_type,string>>(255) |? |Optional remark, can be used to provide addition human readable information to the CDR, for example: reason why a transaction was stopped.
-|credit |boolean |? |When set to 'true', this is a Credit CDR, and the field `credit_reference_id` needs to be set as well.
+|total_time |<<types.asciidoc#types_number_type,number>> |1 |Total duration of the charging session (including the duration of charging and not charging), in hours. 
+|total_parking_time |<<types.asciidoc#types_number_type,number>> |? |Total duration of the charging session where the EV was not charging (no energy was transferred between EVSE and EV), in hours. 
+|remark |<<types.asciidoc#types_string_type,string>>(255) |? |Optional remark, can be used to provide additional human readable information to the CDR, for example: reason why a transaction was stopped.
+|credit |boolean |? |When set to `true`, this is a Credit CDR, and the field `credit_reference_id` needs to be set as well.
 |credit_reference_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |? |Is required to be set for a Credit CDR. This SHALL contain the `id` of the CDR for which this is a Credit CDR.
 |last_updated |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Timestamp when this CDR was last updated (or created).
 |===
 
-NOTE: The duration of charging (energy being transferred between EVSE and EV) during this session can be calculated via: `total_time` - `total_parking_time`. 
+NOTE: The actual charging duration (energy being transferred between EVSE and EV) of a charging session can be calculated: `total_charging_time = total_time - total_parking_time`. 
 
-NOTE: Having both a `credit` and a `credit_reference_id` might seem redundant. But it is seen as an advantage,
-having a boolean flag that can be used for queries, is much faster then string comparisons.
+NOTE: Having both a `credit` and a `credit_reference_id` might seem redundant.
+But it is seen as an advantage as a boolean flag used in queries is much faster than simple string comparison of references.
 
 [[mod_cdrs_example_of_a_cdr]]
 ===== Example of a CDR
@@ -315,8 +313,8 @@ include::examples/cdr_example.json[]
 |===
 |Value |Description 
 
-|AUTH_REQUEST |Authentication request from the eMSP 
-|WHITELIST |Whitelist used to authenticate, no request done to the eMSP 
+|AUTH_REQUEST |Authentication request from the eMSP.
+|WHITELIST |Whitelist used for authentication, no request to the eMSP has been performed.
 |===
 
 [[mod_cdrs_cdrdimension_class]]
@@ -326,7 +324,7 @@ include::examples/cdr_example.json[]
 |===
 |Property |Type |Card. |Description 
 
-|type |<<mod_cdrs_cdrdimensiontype_enum,CdrDimensionType>> |1 |Type of cdr dimension 
+|type |<<mod_cdrs_cdrdimensiontype_enum,CdrDimensionType>> |1 |Type of CDR dimension.
 |volume |<<types.asciidoc#types_number_type,number>> |1 |Volume of the dimension consumed, measured according to the dimension type. 
 |===
 
@@ -337,12 +335,12 @@ include::examples/cdr_example.json[]
 |===
 |Value |Description 
 
-|ENERGY |defined in kWh, default step_size is 1 Wh 
-|MAX_CURRENT |defined in A (Ampere), Maximum current reached during charging session
-|MIN_CURRENT |defined in A (Ampere), Minimum current used during charging session 
-|PARKING_TIME |time not charging: defined in hours, default step_size is 1 second
-|RESERVATION_TIME |time charging station is reserved, and not yet in use for this customer: defined in hours, default step_size is 1 second
-|TIME |time charging: defined in hours, default step_size is 1 second
+|ENERGY |Defined in kWh, default step size is 1 Wh
+|MAX_CURRENT |Maximum current reached during a charging session: defined in A (Ampere)
+|MIN_CURRENT |Minimum current reached during a charging session: defined in A (Ampere)
+|PARKING_TIME |Time not charging: defined in hours, default step size is 1 second
+|RESERVATION_TIME |Time charging station has been reserved and not yet been in use for this customer: defined in hours, default step size is 1 second
+|TIME |Time charging: defined in hours, default step size is 1 second
 |===
 
 
@@ -355,14 +353,14 @@ The _CdrLocation_ class contains only the relevant information from the <<mod_lo
 |===
 |Property |Type |Card. |Description
 
-|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the location within the CPOs platform (and suboperator platforms). This field can never be changed, modified or renamed.
+|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the location within the CPO's platform (and suboperator platforms). This field can never be changed, modified or renamed.
 |name |<<types.asciidoc#types_string_type,string>>(255) |? |Display name of the location.
 |address |<<types.asciidoc#types_string_type,string>>(45) |1 |Street/block name and house number if available.
 |city |<<types.asciidoc#types_string_type,string>>(45) |1 |City or town.
 |postal_code |<<types.asciidoc#types_string_type,string>>(10) |1 |Postal code of the location.
 |country |<<types.asciidoc#types_string_type,string>>(3) |1 |ISO 3166-1 alpha-3 code for the country of this location.
 |coordinates |<<mod_locations_geolocation_class,GeoLocation>> |1 |Coordinates of the location.
-|evse_uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the EVSE within the CPOs platform (and suboperator platforms). For example a database unique ID or the "EVSE ID". This field can never be changed, modified or renamed. This is the 'technical' identification of the EVSE, not to be used as 'human readable' identification, use the field: evse_id for that.
+|evse_uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the EVSE within the CPO's platform (and suboperator platforms). For example a database unique ID or the actual _EVSE ID_. This field can never be changed, modified or renamed. This is the _technical_ identification of the EVSE, not to be used as _human readable_ identification, use the field: `evse_id` for that.
 |evse_id |<<types.asciidoc#types_cistring_type,CiString>>(48) |1 |Compliant with the following specification for EVSE ID from "eMI3 standard version V1.0" (http://emi3group.com/documents-links/[http://emi3group.com/documents-links/]) "Part 2: business objects.".
 |connector_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Identifier of the connector within the EVSE.
 |connector_standard |<<mod_locations.asciidoc#mod_locations_connectortype_enum,ConnectorType>> |1 |The standard of the installed connector.
@@ -379,11 +377,11 @@ The _CdrLocation_ class contains only the relevant information from the <<mod_lo
 |Property |Type |Card. |Description
 
 |uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Unique ID by which this Token can be identified. +
-                                      This is the field used by CPO system (RFID reader on the Charge Point) to identify this token. +
-                                      Currently, in most cases: type=RFID, this is the RFID hidden ID as read by the RFID reader, but that is not a requirement. +
-                                      If this is a type=APP_USER Token, it will be a uniquely, by the eMSP, generated ID.
+This is the field used by the CPO's system (RFID reader on the Charge Point) to identify this token. +
+Currently, in most cases: `type=RFID`, this is the RFID hidden ID as read by the RFID reader, but that is not a requirement. +
+If this is a `type=APP_USER` Token, it will be a uniquely, by the eMSP, generated ID.
 |type |<<mod_tokens_tokentype_enum,TokenType>> |1 |Type of the token
-|contract_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the EV Driver contract token within the eMSP's platform (and suboperator platforms). Recommended to follow the specification for eMA ID from "eMI3 standard version V1.0" (http://emi3group.com/documents-links/[http://emi3group.com/documents-links/]) "Part 2: business objects."
+|contract_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the EV driver contract token within the eMSP's platform (and suboperator platforms). Recommended to follow the specification for eMA ID from "eMI3 standard version V1.0" (http://emi3group.com/documents-links/[http://emi3group.com/documents-links/]) "Part 2: business objects."
 |===
 
 
@@ -391,13 +389,13 @@ The _CdrLocation_ class contains only the relevant information from the <<mod_lo
 [[mod_cdrs_chargingperiod_class]]
 ==== ChargingPeriod _class_
 
-A charging period consists of a start timestamp and a list of possible values that influence this period, for example: Amount of energy charged this period, maximum current during this period etc.
+A Charging Period consists of a start timestamp and a list of possible values that influence this period, for example: amount of energy charged this period, maximum current during this period etc.
 
 [cols="3,2,1,10",options="header"]
 |===
 |Property |Type |Card. |Description 
 
-|start_date_time |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Start timestamp of the charging period. This period ends when a next period starts, the last period ends when the session ends. 
+|start_date_time |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Start timestamp of the charging period. A period ends when the next period starts. The last period ends when the session ends. 
 |dimensions |<<mod_cdrs_cdrdimension_class,CdrDimension>> |+ |List of relevant values for this charging period.
-|tariff_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |? |Uniquely identifier of the tariff that is relevant for this ChargingPeriod. If not provided, no tariff is relevant during this period.
+|tariff_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |? |Unique identifier of the Tariff that is relevant for this Charging Period. If not provided, no Tariff is relevant during this period.
 |===

--- a/mod_charging_profiles.asciidoc
+++ b/mod_charging_profiles.asciidoc
@@ -94,7 +94,7 @@ and an eMSP interface to receive the response from the Location/EVSE asynchronou
 [[mod_charging_profiles_cpo_interface]]
 ==== CPO Interface
 
-ChargingProfiles is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
+ChargingProfiles is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 
 Example endpoint structures:
 

--- a/mod_hub_client_info.asciidoc
+++ b/mod_hub_client_info.asciidoc
@@ -24,7 +24,7 @@ that contain the party_id and country_code of this party.
 ==== Another Party goes OFFLINE
 
 Connection to party is not available: No requests can be send.
-Do not queue push messages. When the other parties comes back online, it is their responsibility to do a GET to get back in sync.
+Do not queue Push messages. When the other parties comes back online, it is their responsibility to do a GET to get back in sync.
 
 ==== Another Party becomes PLANNED
 
@@ -82,7 +82,7 @@ This method is not for operational flow.
 === Interfaces
 
 There is both a Hub interface as a connected client (eMSP/CPO etc) interface for ClientInfo.
-It is advised to use the push direction from Hub to connected clients during normal operation.
+It is advised to use the Push direction from Hub to connected clients during normal operation.
 The Hub interface is meant to be used when the connected client is not 100% sure the ClientInfo cache is still correct.
 
 [[mod_hub_client_info_client_interface]]

--- a/mod_hub_client_info.asciidoc
+++ b/mod_hub_client_info.asciidoc
@@ -18,7 +18,7 @@ This section will describe what the expected behavior is when a party receive in
 ==== Another Party becomes CONNECTED
 
 Party is (back) online. Request can be send again.
-Every party receiving Client Owned Objects from this party should be prepared to received Client Owned Objects with URLs
+Every party receiving Client Owned Objects from this party should be prepared to receive Client Owned Objects with URLs
 that contain the party_id and country_code of this party.
 
 ==== Another Party goes OFFLINE

--- a/mod_hub_client_info.asciidoc
+++ b/mod_hub_client_info.asciidoc
@@ -18,7 +18,7 @@ This section will describe what the expected behavior is when a party receive in
 ==== Another Party becomes CONNECTED
 
 Party is (back) online. Request can be send again.
-Every party receiving Client Owned Object from this party should be prepared to received client owned objects with URLs
+Every party receiving Client Owned Objects from this party should be prepared to received Client Owned Objects with URLs
 that contain the party_id and country_code of this party.
 
 ==== Another Party goes OFFLINE

--- a/mod_locations.asciidoc
+++ b/mod_locations.asciidoc
@@ -173,7 +173,7 @@ The response contains the requested object.
 
 
 [[mod_locations_emsp_interface]]
-===== eMSP Interface
+==== eMSP Interface
 
 Locations are <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Objects>>,
 so the end-points need to contain the required extra fields: 

--- a/mod_locations.asciidoc
+++ b/mod_locations.asciidoc
@@ -6,43 +6,44 @@
 
 *Data owner: `CPO`*
 
-The Location objects live in the CPO back-end system. They describe the charging locations of that operator.
+The Location objects live in the CPO back-end system. They describe the charging locations of one operator (or of multiple operators in case of virtual CPOs).
 
 *Module dependency:* the eMSP endpoint is dependent on the <<mod_tariffs.asciidoc#mod_tariffs_tariffs_module,Tariffs module>>
 
 [[mod_locations_flow_and_lifecycle]]
 === Flow and Lifecycle
 
-The Locations module has Locations as base object, Locations have EVSEs, EVSEs have Connectors.
+The Locations module has Location as base object. Locations can have multiple EVSEs and EVSEs can have multiple Connectors.
 With the methods in the <<mod_locations_emsp_interface,eMSP interface>>,
 Location information/statuses can be shared with the eMSP.
-Updates can be done to the Location, but also to only an EVSE or a Connector.
+Updates can be made to a whole Location, but also to only an EVSE or a Connector.
 
-When a CPO creates Location objects it pushes them to the eMSPs by calling <<mod_locations_put_method,PUT>> on the eMSPs Locations endpoint.
-Providers who do not support push mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the new object.
+When a CPO creates Location objects, it pushes them to the eMSPs by calling <<mod_locations_put_method,PUT>> on the eMSPs Locations endpoint.
+Providers who do not support PUSH mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the new object.
 
 If the CPO wants to replace a Location related object,
 they push it to the eMSP systems by calling <<mod_locations_put_method,PUT>> on their Locations endpoint.
 
 Any changes to a Location related object can also be pushed to the eMSP by calling the <<mod_locations_patch_method,PATCH>>
-on the eMSPs Locations endpoint. Providers who do not support push mode need to
+on the eMSPs Locations endpoint. Providers who do not support PUSH mode need to
 call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the updates.
 
-When the CPO wants to delete an EVSE they must update by setting the `status` field to `REMOVED`
+When the CPO wants to delete an EVSE from the list of active EVSEs, they MUST update by setting the `status` field to `REMOVED`
 and call the <<mod_locations_put_method,PUT>> or <<mod_locations_patch_method,PATCH>> on the eMSP system.
 A _Location_ without valid _EVSE_ objects can be considered as expired and should no longer be displayed.
-There is no direct way to delete a location, EVSE or Connector, there are other modules like <<mod_sessions.asciidoc#mod_sessions_sessions_module,`sessions`>> that link to
-location, EVSE and Connector IDs. If they were removed, these links would no longer work.
+There is no way to entirely delete a Location, EVSE or Connector as there are other modules like <<mod_sessions.asciidoc#mod_sessions_sessions_module,`sessions`>> 
+that depend on Locations, EVSEs and Connector IDs. If they were removed, these links would no longer work.
 
 When the CPO is not sure about the state or existence of a Location, EVSE or Connector object in the eMSPs system,
-the CPO can call the <<mod_locations_get_method_eMSP,GET>> to validate the object in the eMSP system.
+the CPO can perform a <<mod_locations_get_method_eMSP,GET>> request to validate the object in the eMSP system.
 
 [[mod_locations_interfaces_and_endpoints]]
 === Interfaces and endpoints
 
-There is both a CPO and an eMSP interface for Locations. Advised is to use the push direction from CPO to eMSP during normal operation.
-The CPO interface is meant to be used when the connection between 2 parties is established, to retrieve the current list of Location objects with the current status, and when the eMSP is not 100% sure the Locations cache is completely correct.
-The eMSP can use the CPO GET Object interface to retrieve a specific Location, EVSE or Connector, this might be used by a eMSP that wants information about a specific Location, but has not implemented the eMSP Locations interface (cannot receive push).
+There is both a CPO and an eMSP interface for Locations. It is advised to use the PUSH direction from CPO to eMSP during normal operation.
+The CPO interface is meant to be used when the connection between two parties is established, to retrieve the current list of Location objects with the current status, and when the eMSP is not 100% sure the Location cache is entirely up-to-date.
+The eMSP can use the CPO GET Object interface to retrieve a specific Location, EVSE or Connector.
+This feature might be used by an eMSP that wants information about a specific Location, but has not implemented the eMSP Locations interface (i.e. cannot receive PUSH).
 
 [[mod_locations_cpo_interface]]
 ==== CPO Interface
@@ -51,7 +52,7 @@ The eMSP can use the CPO GET Object interface to retrieve a specific Location, E
 |===
 |Method |Description 
 
-|<<mod_locations_get_method,GET>> |Fetch a list locations, last updated between the {date_from} and {date_to} (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>), or get a specific location, EVSE or Connector. 
+|<<mod_locations_get_method,GET>> |Fetch a list of Locations, last updated between the {date_from} and {date_to} (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>), or get a specific Location, EVSE or Connector. 
 |POST |n/a 
 |PUT |n/a 
 |PATCH |n/a 
@@ -62,8 +63,8 @@ The eMSP can use the CPO GET Object interface to retrieve a specific Location, E
 ===== *GET* Method
 
 Depending on the URL Segments provided, the GET request can either be used to retrieve
-information about a list of available locations and EVSEs at this CPO: <<mod_locations_get_list_request_parameters,GET List>>
-Or it can be used to get information about a specific Location, EVSE or Connector: <<mod_locations_get_object_request_parameters,GET Object>>
+information about a list of available Locations (with EVSEs and Connectors) at this CPO (<<mod_locations_get_list_request_parameters,GET List>>)
+or it can be used to get information about one specific Location, EVSE or Connector (<<mod_locations_get_object_request_parameters,GET Object>>).
 
 [[mod_locations_get_list_request_parameters]]
 ====== GET List Request Parameters
@@ -83,8 +84,8 @@ Examples:
 `+https://www.server.com/ocpi/cpo/2.2/locations/?offset=50&amp;limit=100+`
 
 
-If additional parameters: {date_from} and/or {date_to} are provided, only Locations with (`last_updated`) between the given date_from and date_to will be returned.
-If an EVSE is updated, also the 'parent' Location's `last_updated` fields is updated. If a Connector is updated, the EVSE's `last_updated` and the Location's `last_updated` field are updated.
+If additional parameters `{date_from}` and/or `{date_to}` are provided, only Locations with (`last_updated`) between the given `{date_from}` and `{date_to}` will be returned.
+If an EVSE is updated, also the 'parent' Location's `last_updated` field needs to be updated. Analogously, if a Connector is updated, the EVSE's `last_updated` and the Location's `last_updated` fields need to be updated updated.
 
 This request is <<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>, it supports the <<transport_and_format.asciidoc#transport_and_format_paginated_request,pagination>> related URL parameters.
 

--- a/mod_locations.asciidoc
+++ b/mod_locations.asciidoc
@@ -97,7 +97,7 @@ If the optional parameters `{date_from}` and/or `{date_to}` are provided, only L
 (`last_updated`) between the given `{date_from}` and `{date_to}` will be returned.
 In order for this to work properly, the following logic MUST be implemented accordingly:
 If an EVSE is updated, also the 'parent' Location's `last_updated` field needs to be updated. 
-Analogously, if a Connector is updated, the EVSE's `last_updated` and the Location's `last_updated` fields need to be updated.
+Similarly, if a Connector is updated, the EVSE's `last_updated` and the Location's `last_updated` fields need to be updated.
 
 This request is <<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>, it supports the <<transport_and_format.asciidoc#transport_and_format_paginated_request,pagination>> related URL parameters.
 

--- a/mod_locations.asciidoc
+++ b/mod_locations.asciidoc
@@ -13,36 +13,42 @@ The Location objects live in the CPO back-end system. They describe the charging
 [[mod_locations_flow_and_lifecycle]]
 === Flow and Lifecycle
 
-The Locations module has Location as base object. Locations can have multiple EVSEs and EVSEs can have multiple Connectors.
+The Locations module has the <<mod_locations_location_object,Location>> as base object. 
+Each Location can have multiple EVSEs (1:n) and each EVSE can have multiple Connectors (1:n).
 With the methods in the <<mod_locations_emsp_interface,eMSP interface>>,
-Location information/statuses can be shared with the eMSP.
-Updates can be made to a whole Location, but also to only an EVSE or a Connector.
+Location data and status information can be shared with the eMSP.
+Updates can be made to a whole Location, but also only to an EVSE or a single Connector.
 
-When a CPO creates Location objects, it pushes them to the eMSPs by calling <<mod_locations_put_method,PUT>> on the eMSPs Locations endpoint.
-Providers who do not support PUSH mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the new object.
+When a CPO creates Location objects, it pushes them to connected eMSPs by calling <<mod_locations_put_method,PUT>> on the eMSPs Locations endpoint.
+eMSPs who do not support PUSH mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the new object.
+This should be done regularly to stay up to date with the CPOs data, but not too often in order to keep the load low.
 
 If the CPO wants to replace a Location related object,
-they push it to the eMSP systems by calling <<mod_locations_put_method,PUT>> on their Locations endpoint.
+they again push it to the eMSP systems by calling <<mod_locations_put_method,PUT>> on their Locations endpoint.
 
-Any changes to a Location related object can also be pushed to the eMSP by calling the <<mod_locations_patch_method,PATCH>>
-on the eMSPs Locations endpoint. Providers who do not support PUSH mode need to
-call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the updates.
+Any changes to a Location related object can also be pushed to connected eMSPs by calling the <<mod_locations_patch_method,PATCH>> method
+on the eMSPs Locations endpoint, but using PATCH mode, only actual changes should be pushed.
+Providers who do not support PUSH mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the updates.
 
-When the CPO wants to delete an EVSE from the list of active EVSEs, they MUST update by setting the `status` field to `REMOVED`
+When the CPO wants to delete an EVSE from the list of active EVSEs, they MUST update the EVSE's `status` field to `REMOVED`
 and call the <<mod_locations_put_method,PUT>> or <<mod_locations_patch_method,PATCH>> on the eMSP system.
-A _Location_ without valid _EVSE_ objects can be considered as expired and should no longer be displayed.
-There is no way to entirely delete a Location, EVSE or Connector as there are other modules like <<mod_sessions.asciidoc#mod_sessions_sessions_module,`sessions`>> 
-that depend on Locations, EVSEs and Connector IDs. If they were removed, these links would no longer work.
+A Location without any valid EVSE object can be considered expired and should no longer be displayed.
+There is no way to entirely delete Locations, EVSEs and Connectors as there are other modules like 
+<<mod_sessions.asciidoc#mod_sessions_sessions_module,`sessions`>> that depend on them. 
+If it was possible to remove these objects, those links would no longer work.
 
-When the CPO is not sure about the state or existence of a Location, EVSE or Connector object in the eMSPs system,
-the CPO can perform a <<mod_locations_get_method_eMSP,GET>> request to validate the object in the eMSP system.
+When the CPO is not sure about the state or existence of a Location, EVSE or Connector object in the eMSP's system,
+the CPO can perform a <<mod_locations_get_method_eMSP,GET>> request to validate the object in the eMSP's system.
 
 [[mod_locations_interfaces_and_endpoints]]
 === Interfaces and endpoints
 
-There is both a CPO and an eMSP interface for Locations. It is advised to use the PUSH direction from CPO to eMSP during normal operation.
-The CPO interface is meant to be used when the connection between two parties is established, to retrieve the current list of Location objects with the current status, and when the eMSP is not 100% sure the Location cache is entirely up-to-date.
-The eMSP can use the CPO GET Object interface to retrieve a specific Location, EVSE or Connector.
+There are both, a CPO and an eMSP interface for Locations.
+It is advised to use the PUSH direction from CPO to eMSP during normal operation in order to keep the latency of updates low.
+The CPO interface is meant to be used when the connection between two parties is established for the first time,
+to retrieve the current list of Location objects with the current status,
+and when the eMSP is not 100% sure the Location cache is entirely up-to-date (i.e. to perform a full sync).
+The eMSP can also use the CPO <<mod_locations_get_object_request_parameters,GET Object interface>> to retrieve a specific Location, EVSE or Connector.
 This feature might be used by an eMSP that wants information about a specific Location, but has not implemented the eMSP Locations interface (i.e. cannot receive PUSH).
 
 [[mod_locations_cpo_interface]]
@@ -63,29 +69,32 @@ This feature might be used by an eMSP that wants information about a specific Lo
 ===== *GET* Method
 
 Depending on the URL Segments provided, the GET request can either be used to retrieve
-information about a list of available Locations (with EVSEs and Connectors) at this CPO (<<mod_locations_get_list_request_parameters,GET List>>)
-or it can be used to get information about one specific Location, EVSE or Connector (<<mod_locations_get_object_request_parameters,GET Object>>).
+information about a list of available Locations (with EVSEs and Connectors) at a CPO (<<mod_locations_get_list_request_parameters,GET List>>)
+or it can be used to retrieve information about one specific Location, EVSE or Connector (<<mod_locations_get_object_request_parameters,GET Object>>).
 
 [[mod_locations_get_list_request_parameters]]
-====== GET List Request Parameters
+====== GET List: Request Parameters
 
 Endpoint structure definition:
 
-`{locations_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&[offset={offset}]&[limit={limit}]`
+`{locations_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&amp;[offset={offset}]&amp;[limit={limit}]`
 
 Examples:
 
-`+https://www.server.com/ocpi/cpo/2.2/locations/?date_from=2019-01-28T12:00:00&date_to=2019-01-29T12:00:00+`
+`+https://www.server.com/ocpi/cpo/2.2/locations/?date_from=2019-01-28T12:00:00&amp;date_to=2019-01-29T12:00:00+`
 
 `+https://ocpi.server.com/2.2/locations/?offset=50+`
 
-`+https://www.server.com/ocpi/2.2/locations/?date_from=2019-01-29T12:00:00&limit=100+`
+`+https://www.server.com/ocpi/2.2/locations/?date_from=2019-01-29T12:00:00&amp;limit=100+`
 
 `+https://www.server.com/ocpi/cpo/2.2/locations/?offset=50&amp;limit=100+`
 
 
-If additional parameters `{date_from}` and/or `{date_to}` are provided, only Locations with (`last_updated`) between the given `{date_from}` and `{date_to}` will be returned.
-If an EVSE is updated, also the 'parent' Location's `last_updated` field needs to be updated. Analogously, if a Connector is updated, the EVSE's `last_updated` and the Location's `last_updated` fields need to be updated updated.
+If the optional parameters `{date_from}` and/or `{date_to}` are provided, only Locations with 
+(`last_updated`) between the given `{date_from}` and `{date_to}` will be returned.
+In order for this to work properly, the following logic MUST be implemented accordingly:
+If an EVSE is updated, also the 'parent' Location's `last_updated` field needs to be updated. 
+Analogously, if a Connector is updated, the EVSE's `last_updated` and the Location's `last_updated` fields need to be updated.
 
 This request is <<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>, it supports the <<transport_and_format.asciidoc#transport_and_format_paginated_request,pagination>> related URL parameters.
 
@@ -100,27 +109,29 @@ This request is <<transport_and_format.asciidoc#transport_and_format_pagination,
 |===
 
 [[mod_locations_get_list_response_data]]
-====== GET List Response Data
+====== GET List: Response Data
 
-The endpoint returns a list of Location objects
-the header will contain the <<transport_and_format.asciidoc#transport_and_format_paginated_response,pagination>> related headers.
+This endpoint returns a list of Location objects.
+The header will contain the <<transport_and_format.asciidoc#transport_and_format_paginated_response,pagination>> related headers.
 
-Any older information that is not specified in the response is considered no longer valid.
 Each object must contain all required fields. Fields that are not specified may be considered as null values.
+Any old information that is not specified in the response is considered no longer valid.
+For requests that use pagination, the response data provided by all the pages together is the new truth.
+Any old information not contained in any of the pages needs to be considered no longer valid.
 
 [cols="4,1,12",options="header"]
 |===
 |Type |Card. |Description 
 
-|<<mod_locations_location_object,Location>> |* |List of all locations with valid EVSEs. 
+|<<mod_locations_location_object,Location>> |* |List of all Locations with valid EVSEs. 
 |===
 
 [[mod_locations_get_object_request_parameters]]
-====== GET Object Request Parameters
+====== GET Object: Request Parameters
 
 Endpoint structure definition for retrieving a Location, EVSE or Connector:
 
-`{locations_endpoint_url}{location_id}[/{evse_uid}][/{connector_id}]`
+`{locations_endpoint_url}/{location_id}[/{evse_uid}][/{connector_id}]`
 
 Examples:
 
@@ -131,7 +142,7 @@ Examples:
 `+https://www.server.com/ocpi/cpo/2.2/locations/LOC1/3256/1+`
 
 
-The following parameters can be provided as URL segments.
+The following parameters can be provided as URL segments in the same order.
 
 [cols="3,2,1,10",options="header"]
 |===
@@ -143,7 +154,7 @@ The following parameters can be provided as URL segments.
 |===
 
 [[mod_locations_get_object_response_data]]
-====== GET Object Response Data
+====== GET Object: Response Data
 
 The response contains the requested object. 
 
@@ -153,7 +164,7 @@ The response contains the requested object.
 
 |_Choice: one of three_ | | 
 |&gt; <<mod_locations_location_object,Location>> |1 |If a Location object was requested: the Location object. 
-|&gt; <<mod_locations_evse_object,Location>> |1 |If an EVSE object was requested: the EVSE object. 
+|&gt; <<mod_locations_evse_object,EVSE>> |1 |If an EVSE object was requested: the EVSE object. 
 |&gt; <<mod_locations_connector_object,Connector>> |1 |If a Connector object was requested: the Connector object. 
 |===
 
@@ -161,11 +172,13 @@ The response contains the requested object.
 [[mod_locations_emsp_interface]]
 ===== eMSP Interface
 
-Locations is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
+Locations are <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned objects>>,
+so the end-points need to contain the required extra fields: 
+{<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 
 Endpoint structure definition:
 
-`{locations_endpoint_url}{country_code}/{party_id}/{location_id}[/{evse_uid}][/{connector_id}]`
+`{locations_endpoint_url}/{country_code}/{party_id}/{location_id}[/{evse_uid}][/{connector_id}]`
 
 
 Examples:
@@ -183,15 +196,18 @@ Examples:
 
 |<<mod_locations_get_method_eMSP,GET>> |Retrieve a Location as it is stored in the eMSP system. 
 |POST |n/a _(use <<mod_locations_put_method,PUT>>)_ 
-|<<mod_locations_put_method,PUT>> |Push new/updated Location, EVSE and/or Connectors to the eMSP 
-|<<mod_locations_patch_method,PATCH>> |Notify the eMSP of partial updates to a Location, EVSEs or Connector (such as the status). 
-|DELETE |n/a _(use <<mod_locations_patch_method,PATCH>>)_ 
+|<<mod_locations_put_method,PUT>> |Push new/updated Location, EVSE and/or Connector to the eMSP. 
+|<<mod_locations_patch_method,PATCH>> |Notify the eMSP of partial updates to a Location, EVSE or Connector (such as the status). 
+|DELETE |n/a _(use <<mod_locations_patch_method,PATCH>> to update the `status` to `REMOVED` as described in <<mod_locations_flow_and_lifecycle,Flow and Lifecycle>>)_ 
 |===
 
 [[mod_locations_get_method_eMSP]]
 ===== *GET* Method
 
-If the CPO wants to check the status of a Location, EVSE or Connector object in the eMSP system, it might GET the object from the eMSP system for validation purposes. The CPO is the owner of the objects, so it would be illogical if the eMSP system had a different status or was missing an object. If a discrepancy is found, the CPO might push an update to the eMSP via a <<mod_locations_put_method,PUT>> or <<mod_locations_patch_method,PATCH>> call.
+If the CPO wants to check the status of a Location, EVSE or Connector object in the eMSP system,
+it might GET the object from the eMSP system for validation purposes.
+The CPO is the owner of the objects, so it would be illogical if the eMSP system had a different status or was missing an object.
+If a discrepancy is found, the CPO might push an update to the eMSP via a <<mod_locations_put_method,PUT>> or <<mod_locations_patch_method,PATCH>> call.
 
 [[mod_locations_request_parameters]]
 ====== Request Parameters
@@ -202,8 +218,8 @@ The following parameters can be provided as URL segments.
 |===
 |Parameter |Datatype |Required |Description 
 
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting this PUT to the eMSP system.
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting data from the eMSP system.
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting data from the eMSP system.
 |location_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Location.id of the Location object to retrieve.
 |evse_uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |no |Evse.uid, required when requesting an EVSE or Connector object.
 |connector_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |no |Connector.id, required when requesting a Connector object.
@@ -220,7 +236,7 @@ The response contains the requested object.
 
 |_Choice: one of three_ | | 
 |&gt; <<mod_locations_location_object,Location>> |1 |If a Location object was requested: the Location object. 
-|&gt; <<mod_locations_evse_object,Location>> |1 |If an EVSE object was requested: the EVSE object. 
+|&gt; <<mod_locations_evse_object,EVSE>> |1 |If an EVSE object was requested: the EVSE object. 
 |&gt; <<mod_locations_connector_object,Connector>> |1 |If a Connector object was requested: the Connector object. 
 |===
 
@@ -228,12 +244,16 @@ The response contains the requested object.
 [[mod_locations_put_method]]
 ===== *PUT* Method
 
-The CPO pushes available Location/EVSE or Connector objects to the eMSP. PUT is used to send new Location objects to the eMSP, or to replace existing Locations.
+The CPO pushes available Location, EVSE or Connector objects to the eMSP.
+PUT can be used to send new Location objects to the eMSP but also to replace existing Locations.
 
 [[mod_locations_request_parameters_msp]]
 ====== Request Parameters
 
-This is an information push message, the objects pushed will not be owned by the eMSP. To make distinctions between objects being pushed to an eMSP from different CPOs, the {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>} have to be included in the URL, as URL segments.
+This is an information push message, the objects pushed will not be owned by the eMSP.
+To make distinctions between objects being pushed to an eMSP from different CPOs, 
+the {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>} 
+have to be included in the URL (as URL segments, as described in the <<mod_locations_emsp_interface,eMSP Interface>>).
 
 [cols="3,2,1,10",options="header"]
 |===
@@ -241,15 +261,15 @@ This is an information push message, the objects pushed will not be owned by the
 
 |country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting this PUT to the eMSP system.
 |party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.
-|location_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Location.id of the new Location object, or the Location of which an EVSE or Location object is send
-|evse_uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |no |Evse.uid, required when an EVSE or Connector object is send/replaced.
-|connector_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |no |Connector.id, required when a Connector object is send/replaced.
+|location_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Location.id of the new Location object, or the Location of which an EVSE or Connector object is pushed.
+|evse_uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |no |Evse.uid, required when an EVSE or Connector object is pushed.
+|connector_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |no |Connector.id, required when a Connector object is pushed.
 |===
 
 [[mod_locations_request_body]]
 ====== Request Body
 
-The request contains the new/updated object.
+The request body contains the new/updated object.
 
 [cols="4,1,12",options="header"]
 |===
@@ -257,19 +277,22 @@ The request contains the new/updated object.
 
 |_Choice: one of three_ | | 
 |&gt; <<mod_locations_location_object,Location>> |1 |New Location object, or Location object to replace. 
-|&gt; <<mod_locations_evse_object,Location>> |1 |New EVSE object, or EVSE object to replace. 
+|&gt; <<mod_locations_evse_object,EVSE>> |1 |New EVSE object, or EVSE object to replace. 
 |&gt; <<mod_locations_connector_object,Connector>> |1 |New Connector object, or Connector object to replace. 
 |===
 
 [[mod_locations_patch_method]]
 ===== *PATCH* Method
 
-Same as the <<mod_locations_put_method,PUT>> method, but only the fields/objects that have to be updated have to be present, other fields/objects that are not specified are considered unchanged.
+Same as the <<mod_locations_put_method,PUT>> method, but only the fields/objects that have to be updated have to be present.
+Other fields/objects that are not specified as part of the request are considered unchanged.
+Therefore, this method is not suitable to remove information shared earlier.
 
 [[mod_locations_example_a_simple_status_update]]
 ====== Example: a simple status update
 
-This is the most common type of update message to notify eMSPs that an EVSE (EVSE with uid 3255 of Charge Point 1012) is now occupied.
+This is the most common type of update message. It is used to notify eMSPs that the status of an EVSE changed.
+In this case it is the EVSE with uid `3255` of the Location with id `1012`.
 
 [source,json]
 ----
@@ -282,7 +305,7 @@ include::examples/location_patch_example_status.json[]
 [[mod_locations_example_change_the_location_name]]
 ====== Example: change the location name
 
-In this example the name of location 1012 is updated.
+In this example the name of the Location with id `1012` is being updated.
 
 [source,json]
 ----
@@ -296,7 +319,7 @@ include::examples/location_patch_example_location.json[]
 [[mod_locations_example_set_tariff_update]]
 ====== Example: set tariff update
 
-In this example connector 2 of EVSE 1 of Charge Point 1012, receives a new pricing scheme.
+In this example Connector `2` of EVSE `1` of Location `1012` receives a new pricing scheme.
 
 [source,json]
 ----
@@ -309,7 +332,9 @@ include::examples/location_patch_example_tariff.json[]
 [[mod_locations_example_add_an_evse]]
 ====== Example: add an EVSE
 
-To add an _EVSE_, simply put the full object in an update message, including all its required fields. Since the id is new, the receiving party will know that it is a new object. When not all required fields are specified, the object may be discarded.
+To add an _EVSE_, simply put the full object in an update message, including all its required fields.
+Since the id will be new to the eMSP's system, the receiving party will know that it is a new object.
+When not all required fields are specified, the object may be discarded.
 
 [source,json]
 ----
@@ -322,7 +347,7 @@ include::examples/location_patch_example_add_evse.json[]
 [[mod_locations_example_delete_an_evse]]
 ====== Example: delete an EVSE
 
-An EVSE can be deleted by updating its _status_ property.
+An EVSE can be deleted by updating its `status` property.
 
 [source,json]
 ----
@@ -332,8 +357,7 @@ include::examples/location_patch_example_remove_evse.json[]
 ----
 
 
-_Note: To inform that an EVSE is scheduled for removal, the
-status_schedule field can be used._
+_Note: To inform eMSPs that an EVSE is scheduled for removal, the status_schedule field can be used._
 
 [[mod_locations_object_description]]
 === Object description
@@ -346,7 +370,9 @@ image::images/locations-class-diagram.svg[Location class diagram]
 [[mod_locations_location_object]]
 ==== _Location_ Object
 
-The _Location_ object describes the location and its properties where a group of EVSEs that belong together are installed. Typically the _Location_ object is the exact location of the group of EVSEs, but it can also be the entrance of a parking garage which contains these EVSEs. The exact way to reach each EVSE can be further specified by its own properties.
+The _Location_ object describes the location and its properties where a group of EVSEs that belong together are installed.
+Typically, the _Location_ object is the exact location of the group of EVSEs, but it can also be the entrance of a parking garage which contains these EVSEs.
+The exact way to reach each EVSE can be further specified by its own properties.
 
 [cols="7,7,2,16",options="header"]
 |===
@@ -357,8 +383,8 @@ The _Location_ object describes the location and its properties where a group of
 |name |<<types.asciidoc#types_string_type,string>>(255) |? |Display name of the location. 
 |address |<<types.asciidoc#types_string_type,string>>(45) |1 |Street/block name and house number if available. 
 |city |<<types.asciidoc#types_string_type,string>>(45) |1 |City or town. 
-|postal_code |<<types.asciidoc#types_string_type,string>>(10) |? |Postal code of the location, may only be omitted when the location has no postal code: in some countries charging location at highways don't have postal codes.
-|state |<<types.asciidoc#types_string_type,string>>(20) |? |State or Province of the location, only use when relevant.
+|postal_code |<<types.asciidoc#types_string_type,string>>(10) |? |Postal code of the location, may only be omitted when the location has no postal code: in some countries charging locations at highways don't have postal codes.
+|state |<<types.asciidoc#types_string_type,string>>(20) |? |State or province of the location, only to be used when relevant.
 |country |<<types.asciidoc#types_string_type,string>>(3) |1 |ISO 3166-1 alpha-3 code for the country of this location.
 |coordinates |<<mod_locations_geolocation_class,GeoLocation>> |1 |Coordinates of the location. 
 |related_locations |<<mod_locations_additionalgeolocation_class,AdditionalGeoLocation>> |* |Geographical location of related points relevant to the user. 
@@ -367,7 +393,7 @@ The _Location_ object describes the location and its properties where a group of
 |operator |<<mod_locations_businessdetails_class,BusinessDetails>> |? |Information of the operator. When not specified, the information retrieved from the <<credentials.asciidoc#credentials_credentials_endpoint,Credentials>> module should be used instead.
 |suboperator |<<mod_locations_businessdetails_class,BusinessDetails>> |? |Information of the suboperator if available.
 |owner |<<mod_locations_businessdetails_class,BusinessDetails>> |? |Information of the owner if available. 
-|facilities |<<mod_locations_facility_enum,Facility>> |* |Optional list of facilities this charge location directly belongs to. 
+|facilities |<<mod_locations_facility_enum,Facility>> |* |Optional list of facilities this charging location directly belongs to. 
 |time_zone |<<types.asciidoc#types_string_type,string>>(255) |? |One of IANA tzdata's TZ-values representing the time zone of the location. Examples: "Europe/Oslo", "Europe/Zurich". (http://www.iana.org/time-zones[http://www.iana.org/time-zones]) 
 |opening_times |<<mod_locations_hours_class,Hours>> |? |The times when the EVSEs at the location can be accessed for charging. 
 |charging_when_closed |boolean |? |Indicates if the EVSEs are still charging outside the opening hours of the location. E.g. when the parking garage closes its barriers over night, is it allowed to charge till the next morning? Default: *true* 
@@ -389,19 +415,26 @@ include::examples/location_example.json[]
 [[mod_locations_evse_object]]
 ==== _EVSE_ Object
 
-The _EVSE_ object describes the part that controls the power supply to a single EV in a single session. It always belongs to a _Location_ object. It will only contain directions to get from the location to the EVSE (i.e. _floor_, _physical_reference_ or _directions_). When these properties are insufficient to reach the EVSE from the _Location_ point, then it typically indicates that this EVSE should be put in a different _Location_ object (sometimes with the same address but with different coordinates/directions).
+The _EVSE_ object describes the part that controls the power supply to a single EV in a single session.
+It always belongs to a <<mod_locations_location_object,Location>> object. 
+The object only contains directions to get from the location itself
+to the EVSE (i.e. _floor_, _physical_reference_ or _directions_).
 
-An _EVSE_ object has a list of connectors which can not be used simultaneously: only one connector per EVSE can be used at the time.
+When the directional properties of an EVSE are insufficient to reach the EVSE from the _Location_ point,
+then it typically indicates that the EVSE should be put in a different _Location_ object
+(sometimes with the same address but with different coordinates/directions).
+
+An _EVSE_ object has a list of Connectors which can not be used simultaneously: only one connector per EVSE can be used at the time.
 
 [cols="7,5,2,18",options="header"]
 |===
 |Property |Type |Card. |Description 
 
-|uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the EVSE within the CPOs platform (and suboperator platforms). For example a database unique ID or the "EVSE ID". This field can never be changed, modified or renamed. This is the 'technical' identification of the EVSE, not to be used as 'human readable' identification, use the field: `evse_id` for that. +
-This field is named `uid` instead of `id`, because `id` could be confused with `evse_id` which is a eMI3 defined field.
-|evse_id |<<types.asciidoc#types_cistring_type,CiString>>(48) |? |Compliant with the following specification for EVSE ID from "eMI3 standard version V1.0" (http://emi3group.com/documents-links/[http://emi3group.com/documents-links/]) "Part 2: business objects." Optional because: if an EVSE ID is to be re-used the EVSE ID can be removed from an EVSE that is removed (status: REMOVED)
+|uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the EVSE within the CPOs platform (and suboperator platforms). For example a database ID or the actual "EVSE ID". This field can never be changed, modified or renamed. This is the 'technical' identification of the EVSE, not to be used as 'human readable' identification, use the field `evse_id` for that. +
+This field is named `uid` instead of `id`, because `id` could be confused with `evse_id` which is an eMI3 defined field.
+|evse_id |<<types.asciidoc#types_cistring_type,CiString>>(48) |? |Compliant with the following specification for EVSE ID from "eMI3 standard version V1.0" (http://emi3group.com/documents-links/[http://emi3group.com/documents-links/]) "Part 2: business objects." Optional because: if an `evse_id` is to be re-used in the real world, the `evse_id` can be removed from an EVSE object if the `status` is set to `REMOVED`.
 |status |<<mod_locations_status_enum,Status>> |1 |Indicates the current status of the EVSE. 
-|status_schedule |<<mod_locations_statusschedule_class,StatusSchedule>> |* |Indicates a planned status in the future of the EVSE. 
+|status_schedule |<<mod_locations_statusschedule_class,StatusSchedule>> |* |Indicates a planned status update of the EVSE. 
 |capabilities |<<mod_locations_capability_enum,Capability>> |* |List of functionalities that the EVSE is capable of. 
 |connectors |<<mod_locations_connector_object,Connector>> |+ |List of available connectors on the EVSE. 
 |floor_level |<<types.asciidoc#types_string_type,string>>(4) |? |Level on which the charging station is located (in garage buildings) in the locally displayed numbering scheme. 
@@ -417,25 +450,27 @@ This field is named `uid` instead of `id`, because `id` could be confused with `
 [[mod_locations_connector_object]]
 ==== _Connector_ Object
 
-A connector is the socket or cable available for the EV to use. A single EVSE may provide multiple connectors but only one of them can be in use at the same time. A connector always belongs to an _EVSE_ object.
+A _Connector_ is the _socket_ or _cable and plug_ available for the EV to use. 
+A single EVSE may provide multiple Connectors but only one of them can be in use at the same time.
+A Connector always belongs to an <<mod_locations_evse_object,EVSE>> object.
 
 [cols="7,5,2,18",options="header"]
 |===
 |Property |Type |Card. |Description 
 
-|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Identifier of the connector within the EVSE. Two connectors may have the same id as long as they do not belong to the same _EVSE_ object.
+|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Identifier of the Connector within the EVSE. Two Connectors may have the same id as long as they do not belong to the same _EVSE_ object.
 |standard |<<mod_locations_connectortype_enum,ConnectorType>> |1 |The standard of the installed connector. 
 |format |<<mod_locations_connectorformat_enum,ConnectorFormat>> |1 |The format (socket/cable) of the installed connector. 
 |power_type |<<mod_locations_powertype_enum,PowerType>> |1 | 
 |voltage |int |1 |Voltage of the connector (line to neutral for AC_3_PHASE), in volt [V]. 
-|amperage |int |1 |maximum amperage of the connector, in ampere [A].
-|max_electric_power |int |? |Maximum electric power that can be delivered by this connector, in watt [W]. When the maximum electric power is lower then the calculated value from: `voltage` and `amperage`, this value should be set. +
-        For example: A Charge Point which can deliver up to 920V, up to 400A, but max. 150kW. Depending on the car, it may supply max voltage or current, but not both.
-|tariff_ids |<<types.asciidoc#types_cistring_type,CiString>>(36) |* |Identifiers of the current valid charging tariffs. Multiple tariffs are possible, but each require a unique Tariff.type, duplicates not allowed. +
-                                                              When Preference based Smart Charging is supported, on tariff for every possible <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,ProfileType>> should be provided, these tell the Driver the options he has at this Connector, and what the tariff is for every option. +
-                                                              For a "Free of Charge" tariff this field should be set, and point to a defined "Free of Charge" tariff.
+|amperage |int |1 |Maximum amperage of the connector, in ampere [A].
+|max_electric_power |int |? |Maximum electric power that can be delivered by this connector, in watt [W]. When the maximum electric power is lower than the calculated value from `voltage` and `amperage`, this value should be set. +
+For example: A Charge Point which can deliver up to 920V and up to 400A can be limited to a maximum of 150kW. Depending on the car, it may supply max voltage or current, but not both at the same time.
+|tariff_ids |<<types.asciidoc#types_cistring_type,CiString>>(36) |* |Identifiers of the currently valid charging tariffs. Multiple tariffs are possible, but each requires a unique Tariff.type. Duplicates are not allowed. +
+When preference-based smart charging is supported, one tariff for every possible <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,ProfileType>> should be provided. These tell the user about the options they have at this Connector, and what the tariff is for every option. +
+For a "free of charge" tariff, this field should be set and point to a defined "free of charge" tariff.
 |terms_and_conditions |<<types.asciidoc#types_url_type,URL>> |? |URL to the operator's terms and conditions. 
-|last_updated |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Timestamp when this Connectors was last updated (or created). 
+|last_updated |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Timestamp when this Connector was last updated (or created). 
 |===
 
 
@@ -484,8 +519,8 @@ The capabilities of an EVSE.
 |DEBIT_CARD_PAYABLE |Charging at this EVSE can be payed with a debit card.
 |REMOTE_START_STOP_CAPABLE |The EVSE can remotely be <<mod_commands.asciidoc#mod_commands_startsession_object,started>>/<<mod_commands.asciidoc#mod_commands_stopsession_object,stopped>>.
 |RESERVABLE |The EVSE can be <<mod_commands.asciidoc#mod_commands_reservenow_object,reserved>>.
-|RFID_READER |Charging at this EVSE can be authorized with a RFID token 
-|TOKEN_GROUP_CAPABLE |This EVSE supports token groups, two or more tokens work as one, so that a session can be started with one token and stopped with another, handy when a card and key-fob are given to the EV-driver.
+|RFID_READER |Charging at this EVSE can be authorized with an RFID token.
+|TOKEN_GROUP_CAPABLE |This EVSE supports token groups, two or more tokens work as one, so that a session can be started with one token and stopped with another (handy when a card and key-fob are given to the EV-driver).
 |UNLOCK_CAPABLE |Connectors have mechanical lock that can be requested by the eMSP to be <<mod_commands.asciidoc#mod_commands_unlockconnector_object,unlocked>>.
 |===
 
@@ -525,10 +560,10 @@ The socket or plug standard of the charging point.
 |DOMESTIC_J |Standard/Domestic household, type "J", SEV 1011, 3 pins 
 |DOMESTIC_K |Standard/Domestic household, type "K", DS 60884-2-D1, 3 pins 
 |DOMESTIC_L |Standard/Domestic household, type "L", CEI 23-16-VII, 3 pins 
-|IEC_60309_2_single_16 |IEC 60309-2 Industrial Connector single phase 16 Amperes (usually blue) 
-|IEC_60309_2_three_16 |IEC 60309-2 Industrial Connector three phase 16 Amperes (usually red) 
-|IEC_60309_2_three_32 |IEC 60309-2 Industrial Connector three phase 32 Amperes (usually red) 
-|IEC_60309_2_three_64 |IEC 60309-2 Industrial Connector three phase 64 Amperes (usually red) 
+|IEC_60309_2_single_16 |IEC 60309-2 Industrial Connector single phase 16 amperes (usually blue) 
+|IEC_60309_2_three_16 |IEC 60309-2 Industrial Connector three phase 16 amperes (usually red) 
+|IEC_60309_2_three_32 |IEC 60309-2 Industrial Connector three phase 32 amperes (usually red) 
+|IEC_60309_2_three_64 |IEC 60309-2 Industrial Connector three phase 64 amperes (usually red) 
 |IEC_62196_T1 |IEC 62196 Type 1 "SAE J1772" 
 |IEC_62196_T1_COMBO |Combo Type 1 based, DC 
 |IEC_62196_T2 |IEC 62196 Type 2 "Mennekes" 
@@ -590,7 +625,7 @@ include::examples/location_energymix_example_complete.json[lines=2..17]
 [[mod_locations_energysource_class]]
 ==== EnergySource _class_
 
-Key-value pairs (enum + percentage) of energy sources. All given values should add up to 100 percent per category.
+Key-value pairs (enum + percentage) of energy sources. All given values of all categories should add up to 100 percent.
 
 [cols="2,4,1,10",options="header"]
 |===
@@ -672,8 +707,8 @@ Specifies one exceptional period for opening or access hours.
 |MALL |A mall or shopping center. 
 |SUPERMARKET |A supermarket. 
 |SPORT |Sport facilities: gym, field etc. 
-|RECREATION_AREA |A Recreation area. 
-|NATURE |Located in, or close to, a park, nature reserve/park etc. 
+|RECREATION_AREA |A recreation area. 
+|NATURE |Located in, or close to, a park, nature reserve etc. 
 |MUSEUM |A museum. 
 |BUS_STOP |A bus stop. 
 |TAXI_STAND |A taxi stand. 
@@ -695,7 +730,8 @@ Specifies one exceptional period for opening or access hours.
 |longitude |<<types.asciidoc#types_string_type,string>>(11) |1 |Longitude of the point in decimal degree. Example: -126.104965. Decimal separator: "." Regex: `-?[0-9]{1,3}\.[0-9]{5,7}`
 |===
 
-NOTE: Five decimal places is seen as a minimal for GPS coordinates for Charging Stations, this gives approximately 1 meter precision. More is always better. Seven decimal places gives approximately 1cm precision.
+NOTE: Five decimal places is seen as a minimum for GPS coordinates of charging stations as this gives approximately 1 meter precision.
+More is always better. Seven decimal places gives approximately 1cm precision.
 
 
 [[mod_locations_hours_class]]
@@ -709,20 +745,29 @@ Opening and access hours of the location.
 
 |twentyfourseven |boolean |1 |True to represent 24 hours a day and 7 days a week, except the given exceptions. 
 |regular_hours |<<mod_locations_regularhours_class,RegularHours>> |* |Regular hours, weekday-based. Only to be used if `twentyfourseven=false`, then this field needs to contain at least one <<mod_locations_regularhours_class,RegularHours>> object.
-|exceptional_openings |<<mod_locations_exceptionalperiod_class,ExceptionalPeriod>> |* |Exceptions for specified calendar dates, time-range based. Periods the station is operating/accessible. Additional to regular hours. May overlap regular rules. 
-|exceptional_closings |<<mod_locations_exceptionalperiod_class,ExceptionalPeriod>> |* |Exceptions for specified calendar dates, time-range based. Periods the station is not operating/accessible. Overwriting regularHours and exceptionalOpenings. Should not overlap exceptionalOpenings. 
+|exceptional_openings |<<mod_locations_exceptionalperiod_class,ExceptionalPeriod>> |* |Exceptions for specified calendar dates, time-range based. Periods the station is operating/accessible. Additional to `regular_hours`. May overlap regular rules. 
+|exceptional_closings |<<mod_locations_exceptionalperiod_class,ExceptionalPeriod>> |* |Exceptions for specified calendar dates, time-range based. Periods the station is not operating/accessible. Overwriting `regular_hours` and `exceptional_openings`. Should not overlap `exceptional_openings`. 
 |===
 
 [[mod_locations_image_class]]
 ==== Image _class_
 
-This class references images related to a EVSE in terms of a file name or url. According to the roaming connection between one EVSE Operator and one or more Navigation Service Providers the hosting or file exchange of image payload data has to be defined. The exchange of this content data is out of scope of OCHP. However, the recommended setup is a public available web server hosted and updated by the EVSE Operator. Per charge point an unlimited number of images of each type is allowed. Recommended are at least two images where one is a network or provider logo and the second is a station photo. If two images of the same type are defined they should be displayed additionally, not optionally.
+This class references an image related to an EVSE in terms of a file name or url.
+According to the roaming connection between one EVSE Operator and one or more Navigation Service Providers,
+the hosting or file exchange of image payload data has to be defined. The exchange of this content data is out of scope of OCPI.
+However, the recommended setup is a public available web server hosted and updated by the EVSE Operator.
+Per charge point an unlimited number of images of each type is allowed.
+Recommended are at least two images where one is a network or provider logo and the second is a station photo.
+If two images of the same type are defined, not only one should be selected but both should be displayed together.
 
 Photo Dimensions:
-The recommended dimensions for all photos is a minimum of 800 pixels wide and 600 pixels height. Thumbnail representations for photos should always have the same orientation as the original with a size of 200 to 200 pixels.
+The recommended dimensions for all photos is a minimum width of 800 pixels and a minimum height of 600 pixels.
+Thumbnail should always have the same orientation as the original photo with a size of 200 by 200 pixels.
 
 Logo Dimensions:
-The recommended dimensions for logos are exactly 512 pixels wide and 512 pixels height. Thumbnail representations for logos should be exactly 128 pixels in width and height. If not squared, thumbnails should have the same orientation as the original.
+The recommended dimensions for logos are exactly 512 pixels in width height.
+Thumbnail representations of logos should be exactly 128 pixels in width and height.
+If not squared, thumbnails should have the same orientation as the original.
 
 [cols="3,3,1,9",options="header"]
 |===
@@ -739,7 +784,8 @@ The recommended dimensions for logos are exactly 512 pixels wide and 512 pixels 
 [[mod_locations_imagecategory_enum]]
 ==== ImageCategory _enum_
 
-The category of an image to obtain the correct usage in a user presentation. The category has to be set accordingly to the image content in order to guarantee the right usage.
+The category of an image to obtain the correct usage in a user presentation.
+The category has to be set accordingly to the image content in order to guarantee the right usage.
 
 [cols="3,10",options="header"]
 |===
@@ -748,17 +794,16 @@ The category of an image to obtain the correct usage in a user presentation. The
 |CHARGER |Photo of the physical device that contains one or more EVSEs. 
 |ENTRANCE |Location entrance photo. Should show the car entrance to the location from street side. 
 |LOCATION |Location overview photo. 
-|NETWORK |logo of an associated roaming network to be displayed with the EVSE for example in lists, maps and detailed information view 
-|OPERATOR |logo of the charge points operator, for example a municipality, to be displayed with the EVSEs detailed information view or in lists and maps, if no networkLogo is present 
+|NETWORK |Logo of an associated roaming network to be displayed with the EVSE for example in lists, maps and detailed information views.
+|OPERATOR |Logo of the charge point operator, for example a municipality, to be displayed in the EVSEs detailed information view or in lists and maps, if no network logo is present. 
 |OTHER |Other 
-|OWNER |logo of the charge points owner, for example a local store, to be displayed with the EVSEs detailed information view 
+|OWNER |Logo of the charge point owner, for example a local store, to be displayed in the EVSEs detailed information view.
 |===
 
 [[mod_locations_locationtype_enum]]
 ==== LocationType _enum_
 
-Reflects the general type of the charge points location. May be used
-for user information.
+Reflects the general type of the charge point's location. May be used for user information.
 
 [cols="4,9",options="header"]
 |===
@@ -775,8 +820,7 @@ for user information.
 [[mod_locations_parkingrestriction_enum]]
 ==== ParkingRestriction _enum_
 
-This value, if provided, represents the restriction to the parking spot
-for different purposes.
+This value, if provided, represents the restriction to the parking spot for different purposes.
 
 [cols="3,10",options="header"]
 |===
@@ -796,15 +840,15 @@ for different purposes.
 |===
 |Value |Description 
 
-|AC_1_PHASE |AC mono phase. 
-|AC_3_PHASE |AC 3 phase. 
+|AC_1_PHASE |AC single phase. 
+|AC_3_PHASE |AC three phase. 
 |DC |Direct Current. 
 |===
 
 [[mod_locations_regularhours_class]]
 ==== RegularHours _class_
 
-Regular recurring operation or access hours
+Regular recurring operation or access hours.
 
 [cols="3,2,1,10",options="header"]
 |===
@@ -812,7 +856,7 @@ Regular recurring operation or access hours
 
 |weekday |int(1) |1 |Number of day in the week, from Monday (1) till Sunday (7) 
 |period_begin |<<types.asciidoc#types_string_type,string>>(5) |1 |Begin of the regular period given in hours and minutes. Must be in 24h format with leading zeros. Example: "18:15". Hour/Minute separator: ":" Regex: [0-2][0-9]:[0-5][0-9]
-|period_end |<<types.asciidoc#types_string_type,string>>(5) |1 |End of the regular period, syntax as for period_begin. Must be later than period_begin.
+|period_end |<<types.asciidoc#types_string_type,string>>(5) |1 |End of the regular period, syntax as for `period_begin`. Must be later than `period_begin`.
 |===
 
 [[mod_locations_example_a]]
@@ -851,16 +895,18 @@ The status of an EVSE.
 |CHARGING |The EVSE/Connector is in use. 
 |INOPERATIVE |The EVSE/Connector is not yet active or it is no longer available (deleted). 
 |OUTOFORDER |The EVSE/Connector is currently out of order. 
-|PLANNED |The EVSE/Connector is planned, will be operating soon 
-|REMOVED |The EVSE/Connector/charge point is discontinued/removed. 
+|PLANNED |The EVSE/Connector is planned, will be operating soon. 
+|REMOVED |The EVSE/Connector was discontinued/removed. 
 |RESERVED |The EVSE/Connector is reserved for a particular EV driver and is unavailable for other drivers. 
-|UNKNOWN |No status information available. (Also used when offline) 
+|UNKNOWN |No status information available (also used when offline).
 |===
 
 [[mod_locations_statusschedule_class]]
 ==== StatusSchedule _class_
 
-This type is used to schedule status periods in the future. The eMSP can provide this information to the EV user for trip planning purpose. A period MAY have no end. Example: "This station will be running as of tomorrow. Today it is still planned and under construction."
+This type is used to schedule status periods in the future.
+The eMSP can provide this information to the EV user for trip planning purposes. A period MAY have no end.
+Example: "This station will be running as of tomorrow. Today it is still planned and under construction."
 
 [cols="3,2,1,10",options="header"]
 |===
@@ -871,4 +917,4 @@ This type is used to schedule status periods in the future. The eMSP can provide
 |status |<<mod_locations_status_enum,Status>> |1 |Status value during the scheduled period. 
 |===
 
-Note that the scheduled status is purely informational. When the status actually changes, the CPO must push an update to the EVSEs `status` field itself.
+NOTE: The scheduled status is purely informational. When the status actually changes, the CPO must push an update to the EVSEs `status` field itself.

--- a/mod_locations.asciidoc
+++ b/mod_locations.asciidoc
@@ -23,7 +23,7 @@ Location data and status information can be shared with the eMSP.
 Updates can be made to a whole Location, but also only to an EVSE or a single Connector.
 
 When a CPO creates Location objects, it pushes them to connected eMSPs by calling <<mod_locations_put_method,PUT>> on the eMSPs Locations endpoint.
-eMSPs who do not support PUSH mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the new object.
+eMSPs who do not support Push mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the new object.
 This should be done regularly to stay up to date with the CPOs data, but not too often in order to keep the load low.
 
 If the CPO wants to replace a Location related object,
@@ -31,7 +31,7 @@ they again push it to the eMSP systems by calling <<mod_locations_put_method,PUT
 
 Any changes to a Location related object can also be pushed to connected eMSPs by calling the <<mod_locations_patch_method,PATCH>> method
 on the eMSPs Locations endpoint, but using PATCH mode, only actual changes should be pushed.
-Providers who do not support PUSH mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the updates.
+Providers who do not support Push mode need to call <<mod_locations_get_method,GET>> on the CPOs Locations endpoint to receive the updates.
 
 When the CPO wants to delete an EVSE from the list of active EVSEs, they MUST update the EVSE's `status` field to `REMOVED`
 and call the <<mod_locations_put_method,PUT>> or <<mod_locations_patch_method,PATCH>> on the eMSP system.
@@ -47,12 +47,12 @@ the CPO can perform a <<mod_locations_get_method_eMSP,GET>> request to validate 
 === Interfaces and endpoints
 
 There are both, a CPO and an eMSP interface for Locations.
-It is advised to use the PUSH direction from CPO to eMSP during normal operation in order to keep the latency of updates low.
+It is advised to use the Push direction from CPO to eMSP during normal operation in order to keep the latency of updates low.
 The CPO interface is meant to be used when the connection between two parties is established for the first time,
 to retrieve the current list of Location objects with the current status,
 and when the eMSP is not 100% sure the Location cache is entirely up-to-date (i.e. to perform a full sync).
 The eMSP can also use the CPO <<mod_locations_get_object_request_parameters,GET Object interface>> to retrieve a specific Location, EVSE or Connector.
-This feature might be used by an eMSP that wants information about a specific Location, but has not implemented the eMSP Locations interface (i.e. cannot receive PUSH).
+This feature might be used by an eMSP that wants information about a specific Location, but has not implemented the eMSP Locations interface (i.e. cannot receive Push).
 
 [[mod_locations_cpo_interface]]
 ==== CPO Interface
@@ -253,7 +253,7 @@ PUT can be used to send new Location objects to the eMSP but also to replace exi
 [[mod_locations_request_parameters_msp]]
 ====== Request Parameters
 
-This is an information push message, the objects pushed will not be owned by the eMSP.
+This is an information Push message, the objects pushed will not be owned by the eMSP.
 To make distinctions between objects being pushed to an eMSP from different CPOs, 
 the {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>} 
 have to be included in the URL (as URL segments, as described in the <<mod_locations_emsp_interface,eMSP Interface>>).

--- a/mod_locations.asciidoc
+++ b/mod_locations.asciidoc
@@ -175,7 +175,7 @@ The response contains the requested object.
 [[mod_locations_emsp_interface]]
 ===== eMSP Interface
 
-Locations are <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned objects>>,
+Locations are <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Objects>>,
 so the end-points need to contain the required extra fields: 
 {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 

--- a/mod_locations.asciidoc
+++ b/mod_locations.asciidoc
@@ -6,7 +6,10 @@
 
 *Data owner: `CPO`*
 
-The Location objects live in the CPO back-end system. They describe the charging locations of one operator (or of multiple operators in case of virtual CPOs).
+The Location objects live in the CPO back-end system. They describe the charging locations of an operator.
+
+In a multitenant system the Location objects of multiple virtual CPOs live in one back-end system,
+but from the interface perspective there is no interconnection between the data of individual CPOs.
 
 *Module dependency:* the eMSP endpoint is dependent on the <<mod_tariffs.asciidoc#mod_tariffs_tariffs_module,Tariffs module>>
 

--- a/mod_sessions.asciidoc
+++ b/mod_sessions.asciidoc
@@ -28,7 +28,7 @@ When the CPO is not sure about the state or existence of a Session object in the
 
 eMSPs who do not support the Push model need to call <<mod_sessions_cpo_get_method,GET>> on the CPO's Sessions endpoint to receive a list of Sessions.
 
-This <<mod_sessions_cpo_get_method,GET>> method can also be used in combination with the Push model to retrieve Sessions after the system (re-)connects to a CPO, to get a list Sessions 'missed' during a downtime of the eMSP's system.
+This <<mod_sessions_cpo_get_method,GET>> method can also be used in combination with the Push model to retrieve Sessions after the system (re-)connects to a CPO, to get a list Sessions _missed_ during a downtime of the eMSP's system.
 
 
 [[mod_sessions_set_charging_preferences]]

--- a/mod_sessions.asciidoc
+++ b/mod_sessions.asciidoc
@@ -173,7 +173,7 @@ The endpoint response contains a <<mod_sessions_charging_preferences_response_en
 [[mod_sessions_emsp_interface]]
 ===== eMSP Interface
 
-Sessions is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
+Sessions is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 
 Endpoint structure definition:
 

--- a/mod_sessions.asciidoc
+++ b/mod_sessions.asciidoc
@@ -154,7 +154,7 @@ In the body, a <<mod_sessions_charging_preferences_object,ChargingPreferences>> 
 |===
 |Type |Card. |Description
 
-|<<mod_sessions_charging_preferences_object,ChargingPreferences>> |1 | Updated Charging Preferences for the driver of this Session.
+|<<mod_sessions_charging_preferences_object,ChargingPreferences>> |1 | Updated Charging Preferences of the driver for this Session.
 |===
 
 [[mod_sessions_cpo_post_response_data]]

--- a/mod_sessions.asciidoc
+++ b/mod_sessions.asciidoc
@@ -13,44 +13,44 @@ The Session object is owned by the CPO back-end system, and can be GET from the 
 === Flow and Lifecycle
 
 [[mod_sessions_push_model]]
-==== Push model
+==== PUSH model
 
-When the CPO creates a Session object they push it to the eMSPs by calling <<mod_sessions_msp_put_method,PUT>> on the eMSPs Sessions endpoint with the newly created Session object.
+When the CPO creates a Session object they push it to the corresponding eMSP by calling <<mod_sessions_msp_put_method,PUT>> on the eMSP's Sessions endpoint with the newly created Session object.
 
-Any changes to a Session in the CPO system are sent to the eMSP system by calling <<mod_sessions_patch_method,PATCH>> on the eMSPs Sessions endpoint with the updated Session object.
+Any changes to a Session in the CPO system are sent to the eMSP system by calling <<mod_sessions_patch_method,PATCH>> on the eMSP's Sessions endpoint with the updated Session object.
 
 Sessions cannot be deleted, final status of a session is: `COMPLETED`.
 
-When the CPO is not sure about the state or existence of a Session object in the eMSPs system, the CPO can call the <<mod_sessions_msp_get_method,GET>> to validate the Session object in the eMSP system. 
+When the CPO is not sure about the state or existence of a Session object in the eMSP's system, the CPO can call <<mod_sessions_msp_get_method,GET>> on the eMSP's Sessions endpoint to validate the Session object in the eMSP's system.
 
 [[mod_sessions_pull_model]]
-==== Pull model
+==== PULL model
 
-eMSPs who do not support the push model need to call <<mod_sessions_cpo_get_method,GET>> on the CPOs Sessions endpoint to receive a list of Sessions.
+eMSPs who do not support the PUSH model need to call <<mod_sessions_cpo_get_method,GET>> on the CPO's Sessions endpoint to receive a list of Sessions.
 
-This <<mod_sessions_cpo_get_method,GET>> can also be used, combined with the Push model to retrieve Sessions after the system (re)connects to a CPO, to get a list Sessions 'missed' during a time offline.
+This <<mod_sessions_cpo_get_method,GET>> method can also be used in combination with the PUSH model to retrieve Sessions after the system (re-)connects to a CPO, to get a list Sessions 'missed' during a downtime of the eMSP's system.
 
 
 [[mod_sessions_set_charging_preferences]]
-==== Set charging preferences
+==== Set: Charging Preferences
 
 For a lot of smart charging use cases, input from the driver is needed.
-The smart charging algorithms need to be able to give certain session priority over others,
-need to know how much energy an EV needs before what time.
-Via a <<mod_sessions_cpo_put_method,PUT>> on the CPO Interface, during an ongoing session,
-the eMSP can send <<mod_sessions_charging_preferences_object,Charging Preferences>> for the driver.
-Indicating the preferences of the driver to the CPO.
+The smart charging algorithms need to be able to give certain session priority over others.
+In other words they need to know how much energy an EV needs before what time.
+Via a <<mod_sessions_cpo_put_method,PUT>> request on the CPO Interface, during an ongoing session,
+the eMSP can send <<mod_sessions_charging_preferences_object,Charging Preferences>> on behalf of the driver.
 
 The eMSP can determine if an EVSE supports Charging Preferences by checking if the
 <<mod_locations.asciidoc#mod_locations_evse_object,EVSE capabilities>> contains:
 <<mod_locations.asciidoc#mod_locations_capability_enum,CHARGING_PREFERENCES_CAPABLE>>.
 
-Via <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariffs>> the CPO can give different preferences different prices.
-A <<mod_locations.asciidoc#mod_locations_connector_object,Connector>> can have multiple <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariffs>> one for each <<mod_sessions_profile_type_enum,ProfileType>>.
+Via <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariffs>> the CPO can give different Charging Preferences different prices.
+A <<mod_locations.asciidoc#mod_locations_connector_object,Connector>> can have multiple <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariffs>>,
+one for each <<mod_sessions_profile_type_enum,ProfileType>>.
 
 
 [[mod_sessions_interfaces_and_endpoints]]
-=== Interfaces and endpoints
+=== Interfaces and Endpoints
 
 [[mod_sessions_cpo_interface]]
 ==== CPO Interface
@@ -59,9 +59,9 @@ A <<mod_locations.asciidoc#mod_locations_connector_object,Connector>> can have m
 |===
 |Method |Description 
 
-|<<mod_sessions_cpo_get_method,GET>> |Fetch Session objects of charging sessions last updated between the {date_from} and {date_to} (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>) 
+|<<mod_sessions_cpo_get_method,GET>> |Fetch Session objects of charging sessions last updated between the `{date_from}` and `{date_to}`(<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>).
 |POST |n/a
-|<<mod_sessions_cpo_put_method,PUT>> |Setting charging preferences on an ongoing session.
+|<<mod_sessions_cpo_put_method,PUT>> |Setting Charging Preferences of an ongoing session.
 |PATCH |n/a
 |DELETE |n/a 
 |===
@@ -69,19 +69,19 @@ A <<mod_locations.asciidoc#mod_locations_connector_object,Connector>> can have m
 [[mod_sessions_cpo_get_method]]
 ===== *GET* Method
 
-Fetch Sessions from the CPO systems.
+Fetch Sessions from a CPO system.
 
 Endpoint structure definition:
 
-`{sessions_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&[offset={offset}]&[limit={limit}]`
+`{sessions_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&amp;[offset={offset}]&amp;[limit={limit}]`
 
 Examples:
 
-`+https://www.server.com/ocpi/cpo/2.2/sessions/?date_from=2019-01-28T12:00:00&date_to=2019-01-29T12:00:00+`
+`+https://www.server.com/ocpi/cpo/2.2/sessions/?date_from=2019-01-28T12:00:00&amp;date_to=2019-01-29T12:00:00+`
 
 `+https://ocpi.server.com/2.2/sessions/?offset=50+`
 
-`+https://www.server.com/ocpi/2.2/sessions/?date_from=2019-01-29T12:00:00&limit=100+`
+`+https://www.server.com/ocpi/2.2/sessions/?date_from=2019-01-29T12:00:00&amp;limit=100+`
 
 `+https://www.server.com/ocpi/cpo/2.2/sessions/?offset=50&amp;limit=100+`
 
@@ -89,9 +89,9 @@ Examples:
 [[mod_sessions_cpo_get_request_parameters]]
 ====== Request Parameters
 
-Only Sessions with `last_update` between the given {date_from} and {date_to} will be returned.
+Only Sessions with `last_update` between the given `{date_from}` and `{date_to}` will be returned.
 
-This request is <<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>, so also supports the <<transport_and_format.asciidoc#transport_and_format_paginated_request,pagination>> related URL parameters.
+This request is <<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>, it supports the <<transport_and_format.asciidoc#transport_and_format_paginated_request,pagination>> related URL parameters.
 
 [cols="3,2,1,10",options="header"]
 |===
@@ -108,13 +108,13 @@ This request is <<transport_and_format.asciidoc#transport_and_format_pagination,
 
 The response contains a list of Session objects that match the given parameters in the request, the header will contain the <<transport_and_format.asciidoc#transport_and_format_paginated_response,pagination>> related headers. 
 
-Any older information that is not specified in the response is considered as no longer valid.
+Any older information that is not specified in the response is considered no longer valid.
 Each object must contain all required fields. Fields that are not specified may be considered as null values.
 
 |===
 |Datatype |Card. |Description 
 
-|<<mod_sessions_session_object,Session>> |* |List of Session objects that match the request parameters 
+|<<mod_sessions_session_object,Session>> |* |List of Session objects that match the request parameters.
 |===
 
 
@@ -125,13 +125,13 @@ Set/update the drivers Charging Preferences for this charging session.
 
 Endpoint structure definition:
 
-`{sessions_endpoint_url}{session_id}/charging_preferences`
+`{sessions_endpoint_url}/{session_id}/charging_preferences`
 
 Examples:
 
 `+https://www.server.com/ocpi/cpo/2.2/sessions/1234/charging_preferences+`
 
-The `/charging_preferences` is required when setting Charging Preferences.
+NOTE: The `/charging_preferences` URL suffix is required when setting Charging Preferences.
 
 [[mod_sessions_cpo_post_request_parameters]]
 ====== Request Parameters
@@ -142,25 +142,25 @@ The following parameter has to be provided as URL segments.
 |===
 |Parameter |Datatype |Required |Description
 
-|session_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Session.id of the Session on which these Charging Preferences are to be set.
+|session_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Session.id of the Session for which the Charging Preferences are to be set.
 |===
 
 [[mod_sessions_cpo_post_request_body]]
 ====== Request Body
 
-In the body a <<mod_sessions_charging_preferences_object,ChargingPreferences>> object has to be provided.
+In the body, a <<mod_sessions_charging_preferences_object,ChargingPreferences>> object has to be provided.
 
 [cols="4,1,12",options="header"]
 |===
 |Type |Card. |Description
 
-|<<mod_sessions_charging_preferences_object,ChargingPreferences>> |1 | Updated Charging preferences for the driver for this Session.
+|<<mod_sessions_charging_preferences_object,ChargingPreferences>> |1 | Updated Charging Preferences for the driver of this Session.
 |===
 
 [[mod_sessions_cpo_post_response_data]]
 ====== Response Data
 
-The endpoint response contains a <<mod_sessions_charging_preferences_response_enum,ChargingPreferencesResponse>> value.
+The response contains a <<mod_sessions_charging_preferences_response_enum,ChargingPreferencesResponse>> value.
 
 [cols="4,1,12",options="header"]
 |===
@@ -173,11 +173,12 @@ The endpoint response contains a <<mod_sessions_charging_preferences_response_en
 [[mod_sessions_emsp_interface]]
 ===== eMSP Interface
 
-Sessions is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
+Sessions are <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Objects>>,
+so the endpoints need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 
 Endpoint structure definition:
 
-`{sessions_endpoint_url}{country_code}/{party_id}/{session_id}`
+`{sessions_endpoint_url}/{country_code}/{party_id}/{session_id}`
 
 Example:
 
@@ -188,18 +189,18 @@ Example:
 |===
 |Method |Description 
 
-|<<mod_sessions_msp_get_method,GET>> |Get the Session object from the eMSP system by its id {session_id}. 
+|<<mod_sessions_msp_get_method,GET>> |Retrieve a Session object from the eMSP's system with Session.id equal to `{session_id}`.
 |POST |n/a 
-|<<mod_sessions_msp_put_method,PUT>> |Send a new/updated Session object
-|<<mod_sessions_patch_method,PATCH>> |Update the Session object of id {session_id}. 
+|<<mod_sessions_msp_put_method,PUT>> |Send a new/updated Session object to the eMSP.
+|<<mod_sessions_patch_method,PATCH>> |Update the Session object with Session.id equal to `{session_id}`.
 |DELETE |n/a 
 |===
 
 [[mod_sessions_msp_get_method]]
 ===== *GET* Method
 
-The CPO system might request the current version of a Session object from the eMSP system for,
-for example validation purposes, or the CPO system might have received a error on a PATCH.
+The CPO system might request the current version of a Session object from the eMSP's system to,
+for example, validate the state, or because the CPO has received an error during a PATCH operation.
 
 [[mod_sessions_msp_get_request_parameters]]
 ====== Request Parameters
@@ -210,26 +211,26 @@ The following parameters can be provided as URL segments.
 |===
 |Parameter |Datatype |Required |Description 
 
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting this GET to the eMSP system.
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting this GET to the eMSP system.
-|session_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |id of the Session object to get from the eMSP system.
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO performing the GET on the eMSP's system.
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO performing the GET on the eMSP's system.
+|session_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |id of the Session object to get from the eMSP's system.
 |===
 
 [[mod_sessions_msp_get_response_data]]
 ====== Response Data
 
-The response contains the request Session object, if available.
+The response contains the requested Session object.
 
 |===
 |Datatype |Card. |Description 
 
-|<<mod_sessions_session_object,Session>> |1 |Session object requested. 
+|<<mod_sessions_session_object,Session>> |1 |Requested Session object. 
 |===
 
 [[mod_sessions_msp_put_method]]
 ===== *PUT* Method
 
-Inform the system about a new/updated session in the eMSP backoffice by PUTing a _Session_ object.
+Inform the eMSP's system about a new/updated Session object in the CPO's system.
 
 [[mod_sessions_request_body]]
 ====== Request Body
@@ -240,7 +241,7 @@ The request contains the new or updated Session object.
 |===
 |Type |Card. |Description 
 
-|<<mod_sessions_session_object,Session>> |1 |new Session object. 
+|<<mod_sessions_session_object,Session>> |1 |New or updated Session object.
 |===
 
 
@@ -253,22 +254,22 @@ The following parameters can be provided as URL segments.
 |===
 |Parameter |Datatype |Required |Description 
 
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting this PUT to the eMSP system.
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO performing this PUT on the eMSP's system.
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO performing this PUT on the eMSP's system.
 |session_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |id of the new or updated Session object.
 |===
 
 [[mod_sessions_patch_method]]
 ===== *PATCH* Method
 
-Same as the <<mod_sessions_msp_put_method,PUT>> method, but only the fields/objects that have to be updated have to be present, other fields/objects that are not specified are considered unchanged.
+Same as the <<mod_sessions_msp_put_method,PUT>> method, but only the fields/objects that need to be updated have to be present. Fields/objects which are not specified are considered unchanged.
 
 [[mod_sessions_example_update_the_total_cost]]
 ====== Example: update the total cost
 
 [source,json]
 ----
-PATCH To URL: https://www.server.com/ocpi/cpo/2.2/sessions/NL/TNM/101
+PATCH https://www.server.com/ocpi/cpo/2.2/sessions/NL/TNM/101
 
 include::examples/session_patch_example_total_cost.json[]
 ----
@@ -279,18 +280,22 @@ include::examples/session_patch_example_total_cost.json[]
 [[mod_sessions_session_object]]
 ==== _Session_ Object
 
-The Session object describes one charging session. That does not mean that it is required that energy has been transferred between EV and Charge Point.
-It is possible that the EV never takes energy from the Charge Point because it was instructed not to take energy by the driver.
-But as the EV was connected to the Charge Point, some form of start tariff, reservation cost and park tariff might be relevant.
-OCPI allows this, local laws might not allow this.
+The Session object describes one charging session. That doesn't mean it is required that energy has been transferred between EV and the Charge Point.
+It is possible that the EV never took energy from the Charge Point because it was instructed not to take energy by the driver.
+But as the EV was connected to the Charge Point, some form of start tariff, park tariff or reservation cost might be relevant.
 
-It is recommended to add enough CharingPeriodes to a Session so the eMSP can provide feedback to the EV Driver
-about the progress of the Charging Session.
-That means, depending on the charging speed, a Charging Periode that is useful for feedback,
-how often that is is left to the CPO.
-Adding a new ChargingPeriod every minute for an AC charging session can be too much.
-A new ChargingPeriod every 30 minutes for a DC Fast Charging session is not enough.
-It is also recommended to add ChargingPeriods for all moments that are relevant for the Tariff changes,
+NOTE: Although OCPI supports such pricing mechanisms, local laws might not allow this.
+
+It is recommended to add enough `ChargingPeriods` to a Session so that the eMSP is able to provide feedback to the EV driver
+about the progress of the charging session.
+The ideal amount of transmitted Charging Periods depends on the charging speed.
+The Charging Periods should be sufficient for useful feedback but they should not generate too much unneeded traffic either.
+How many Charging Periods are transmitted is left to the CPO to decide. The following are just some points to consider:
+
+- Adding a new Charging Period every minute for an AC charging session can be too much as it will yield 180 Charging Periods for an (assumed to be) average 3h session.
+- A new Charging Period every 30 minutes for a DC fast charging session is not enough as it will yield only one Charging Period for an (assumed to be) average 30min session.
+
+It is also recommended to add Charging Periods for all moments that are relevant for the Tariff changes,
 see <<mod_cdrs.asciidoc#mod_cdrs_cdr_object,CDR description>> for more information.
 
 
@@ -298,19 +303,19 @@ see <<mod_cdrs.asciidoc#mod_cdrs_cdr_object,CDR description>> for more informati
 |===
 |Property |Type |Card. |Description 
 
-|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |The unique id that identifies the session in the CPO platform.
+|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |The unique id that identifies the charging session in the CPO platform.
 |start_datetime |<<types.asciidoc#types_datetime_type,DateTime>> |1 |The time when the session became active. 
-|end_datetime |<<types.asciidoc#types_datetime_type,DateTime>> |? |The time when the session is completed. 
-|kwh |<<types.asciidoc#types_number_type,number>> |1 |How many kWh are charged. 
-|cdr_token |<<mod_cdrs.asciidoc#mod_cdrs_cdr_token_object,CdrToken>> |1 |Token used to start this Charging Session, includes all the relevant information to identify the unique token.
+|end_datetime |<<types.asciidoc#types_datetime_type,DateTime>> |? |The time when the session was completed. 
+|kwh |<<types.asciidoc#types_number_type,number>> |1 |How many kWh were charged. 
+|cdr_token |<<mod_cdrs.asciidoc#mod_cdrs_cdr_token_object,CdrToken>> |1 |Token used to start this charging session, including all the relevant information to identify the unique token.
 |auth_method |<<mod_cdrs.asciidoc#mod_cdrs_authmethod_enum,AuthMethod>> |1 |Method used for authentication.
-|location_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Location.id of the Location object of this CPO, on which the Charging Session is ongoing.
-|evse_uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |EVSE.uid of the EVSE of this Location on which the Charging Session is ongoing.
-|connector_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Connector.id of the Connector of this Location the Charging Session is ongoing.
+|location_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Location.id of the Location object of this CPO, on which the charging session is/was happening.
+|evse_uid |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |EVSE.uid of the EVSE of this Location on which the charging session is/was happening.
+|connector_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Connector.id of the Connector of this Location the charging session is/was happening.
 |meter_id |<<types.asciidoc#types_string_type,string>>(255) |? |Optional identification of the kWh meter. 
 |currency |<<types.asciidoc#types_string_type,string>>(3) |1 |ISO 4217 code of the currency used for this session. 
-|charging_periods |<<mod_cdrs.asciidoc#mod_cdrs_chargingperiod_class,ChargingPeriod>> |* |An optional list of charging periods that can be used to calculate and verify the total cost. 
-|total_cost |<<types.asciidoc#types_price_class,Price>> |? |The total cost (excluding VAT) of the session in the specified currency. This is the price that the eMSP will have to pay to the CPO. A total_cost of 0.00 means free of charge. When omitted, no price information is given in the Session object, this does not have to mean it is free of charge.
+|charging_periods |<<mod_cdrs.asciidoc#mod_cdrs_chargingperiod_class,ChargingPeriod>> |* |An optional list of Charging Periods that can be used to calculate and verify the total cost. 
+|total_cost |<<types.asciidoc#types_price_class,Price>> |? |The total cost (excluding VAT) of the session in the specified currency. This is the price that the eMSP will have to pay to the CPO. A total_cost of 0.00 means free of charge. When omitted, i.e. no price information is given in the Session object, it does not imply the session is/was free of charge.
 |status |<<mod_sessions_sessionstatus_enum,SessionStatus>> |1 |The status of the session.
 |last_updated |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Timestamp when this Session was last updated (or created). 
 |===
@@ -320,7 +325,7 @@ see <<mod_cdrs.asciidoc#mod_cdrs_cdr_object,CDR description>> for more informati
 ===== Examples
 
 [[mod_sessions_simple_session_example_of_a_just_starting_session]]
-====== Simple Session example of a just starting session
+====== Simple Session example of just starting a session
 
 [source,json]
 ----
@@ -340,42 +345,41 @@ include::examples/session_example_2_short_finished.json[]
 [[mod_sessions_charging_preferences_object]]
 ==== _ChargingPreferences_ Object
 
-Contains the charging preferences for an EV driver.
+Contains the charging preferences of an EV driver.
 
 [cols="3,2,1,10",options="header"]
 |===
 |Property |Type |Card. |Description
 
 |profile_type |<<mod_sessions_profile_type_enum,ProfileType>> |1 |Type of Smart Charging Profile selected by the driver.
-            The <<mod_sessions_profile_type_enum,ProfileType>> has to be supported at the <<mod_locations.asciidoc#mod_locations_connector_object,Connector>>,
-            for every supported <<mod_sessions_profile_type_enum,ProfileType>>, a <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariff>> is provided. This gives the EV Driver the option between different pricing options.
-|departure_time |<<types.asciidoc#types_datetime_type,DateTime>> |? |Expected departure. Driver has given this datetime as expected departure moment, which does not mean that that will be the real departure time.
-|energy_need |<<types.asciidoc#types_number_type,number>> |? |Requested amount of energy in kWh. EV drivers wants to have this amount of energy charged.
-|discharge_allowed |boolean |? | Driver allows his/her EV to be discharged when needed, as long as the other preferences are met: EV is charged with the preferred energy at the preferred momement. Default if omitted: *false*.
+The <<mod_sessions_profile_type_enum,ProfileType>> has to be supported at the <<mod_locations.asciidoc#mod_locations_connector_object,Connector>> and
+for every supported <<mod_sessions_profile_type_enum,ProfileType>>, a <<mod_tariffs.asciidoc#mod_tariffs_tariff_object,Tariff>> MUST be provided.
+This gives the EV driver the option between different pricing options.
+|departure_time |<<types.asciidoc#types_datetime_type,DateTime>> |? |Expected departure. The driver has given this Date/Time as expected departure moment. It is only an estimation and not necessarily the Date/Time of the actual departure.
+|energy_need |<<types.asciidoc#types_number_type,number>> |? |Requested amount of energy in kWh. The EV driver wants to have this amount of energy charged.
+|discharge_allowed |boolean |? |The driver allows their EV to be discharged when needed, as long as the other preferences are met: EV is charged with the preferred energy (`energy_need`) until the preferred departure moment (`departure_time`). Default if omitted: *false*
 |===
 
 
 [[mod_sessions_data_types]]
 === Data types
 
-_Describe all datatypes used in this object_
-
 [[mod_sessions_charging_preferences_response_enum]]
 ==== ChargingPreferencesResponse _enum_
 
 Different smart charging profile types.
 
-No value for NOT_SUPPORTED, when a PUT for ChargingPreferences is received for a EVSE that does not support it: use HTTP 404.
+No value should be returned instead of `NOT_SUPPORTED` when a PUT with `ChargingPreferences` is received for an EVSE that does not have the capability `CHARGING_PROFILE_CAPABLE`. Use HTTP 404 instead.
 
 [cols="5,8",options="header"]
 |===
 |Value |Description
 
-|ACCEPTED | Charging Preferences accepted, EVSE will try to execute them, this is no guarantee that they will be fulfilled.
-|DEPARTURE_REQUIRED | CPO requires departure time to be able to do Charging Preference based Smart Charging.
-|ENERGY_NEED_REQUIRED | CPO requires energy_need to be able to do Charging Preference based Smart Charging.
-|NOT_POSSIBLE | Charging Preferences contain a request that the EVSE knows it cannot fulfill.
-|PROFILE_TYPE_NOT_SUPPORTED | profile_type contains a value that is not supported by the EVSE.
+|ACCEPTED |Charging Preferences accepted, EVSE will try to accomplish them, although this is no guarantee that they will be fulfilled.
+|DEPARTURE_REQUIRED |CPO requires `departure_time` to be able to perform Charging Preference based Smart Charging.
+|ENERGY_NEED_REQUIRED |CPO requires `energy_need` to be able to perform Charging Preference based Smart Charging.
+|NOT_POSSIBLE |Charging Preferences contain a demand that the EVSE knows it cannot fulfill.
+|PROFILE_TYPE_NOT_SUPPORTED |`profile_type` contains a value that is not supported by the EVSE.
 |===
 
 
@@ -388,10 +392,10 @@ Different smart charging profile types.
 |===
 |Value |Description
 
-|CHEAP   | Driver wants to use the cheapest charging profile possible.
-|FAST    | Driver wants his EV charged as quickly as possible and is willing to pay a premium for this, if needed.
-|GREEN   | Driver wants his EV charged which as much regenerative (green) power as possible.
-|REGULAR | Driver does not have special preferences.
+|CHEAP   |Driver wants to use the cheapest charging profile possible.
+|FAST    |Driver wants his EV charged as quickly as possible and is willing to pay a premium for this, if needed.
+|GREEN   |Driver wants his EV charged with as much regenerative (green) energy as possible.
+|REGULAR |Driver does not have special preferences.
 |===
 
 
@@ -404,8 +408,8 @@ Defines the state of a session.
 |===
 |Value |Description
 
-|ACTIVE |The session is accepted and active. Al pre-condition are met: Communication between EV and EVSE (for example: cable plugged in correctly), EV or Driver is authorized. EV is being charged, or can be charged. Energy is, or is not, being transfered. 
-|COMPLETED |The session is finished successfully. No more modifications will be made to this session. 
-|INVALID |The session is declared invalid and will not be billed. 
-|PENDING |The session is pending, it has not yet started. Not all pre-condition are met. This is the initial state. This session might never become an _active_ session. 
+|ACTIVE |The session has been accepted and is active. All pre-conditions were met: Communication between EV and EVSE (for example: cable plugged in correctly), EV or driver is authorized. EV is being charged, or can be charged. Energy is, or is not, being transfered. 
+|COMPLETED |The session has been finished successfully. No more modifications will be made to the Session object using this state. 
+|INVALID |The Session object using this state is declared invalid and will not be billed. 
+|PENDING |The session is pending, it has not yet started. Not all pre-conditions are met. This is the initial state. The session might never become an _active_ session. 
 |===

--- a/mod_sessions.asciidoc
+++ b/mod_sessions.asciidoc
@@ -13,7 +13,7 @@ The Session object is owned by the CPO back-end system, and can be GET from the 
 === Flow and Lifecycle
 
 [[mod_sessions_push_model]]
-==== PUSH model
+==== Push model
 
 When the CPO creates a Session object they push it to the corresponding eMSP by calling <<mod_sessions_msp_put_method,PUT>> on the eMSP's Sessions endpoint with the newly created Session object.
 
@@ -24,11 +24,11 @@ Sessions cannot be deleted, final status of a session is: `COMPLETED`.
 When the CPO is not sure about the state or existence of a Session object in the eMSP's system, the CPO can call <<mod_sessions_msp_get_method,GET>> on the eMSP's Sessions endpoint to validate the Session object in the eMSP's system.
 
 [[mod_sessions_pull_model]]
-==== PULL model
+==== Pull model
 
-eMSPs who do not support the PUSH model need to call <<mod_sessions_cpo_get_method,GET>> on the CPO's Sessions endpoint to receive a list of Sessions.
+eMSPs who do not support the Push model need to call <<mod_sessions_cpo_get_method,GET>> on the CPO's Sessions endpoint to receive a list of Sessions.
 
-This <<mod_sessions_cpo_get_method,GET>> method can also be used in combination with the PUSH model to retrieve Sessions after the system (re-)connects to a CPO, to get a list Sessions 'missed' during a downtime of the eMSP's system.
+This <<mod_sessions_cpo_get_method,GET>> method can also be used in combination with the Push model to retrieve Sessions after the system (re-)connects to a CPO, to get a list Sessions 'missed' during a downtime of the eMSP's system.
 
 
 [[mod_sessions_set_charging_preferences]]

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -29,7 +29,7 @@ CPO can call the <<mod_tariffs_msp_get_method,GET>> to validate the Tariff objec
 [[mod_tariffs_pull_model]]
 ==== Pull model
 
-eMSPs who do not support the push model need to call
+eMSPs who do not support the Push model need to call
 <<mod_tariffs_cpo_get_method,GET>> on the CPOs Tariff endpoint to receive
 all Tariffs, replacing the current list of known Tariffs with the newly received list.
 

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -111,7 +111,7 @@ Each object must contain all required fields. Fields that are not specified may 
 [[mod_tariffs_emsp_interface]]
 ==== eMSP Interface
 
-Tariffs is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
+Tariffs is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 
 Endpoint structure definition:
 

--- a/mod_tokens.asciidoc
+++ b/mod_tokens.asciidoc
@@ -33,7 +33,7 @@ When a CPO is not sure about the state of the list of known Tokens, or wants to 
 list as a start-up of their system, the CPO can call the <<mod_tokens_msp_get_method,GET>> on the eMSP's Token endpoint to receive
 all Tokens, updating already known Tokens and adding new received Tokens to it own list of Tokens.
 This is not intended for real-time operation, requesting the full list of tokens for every authorization will put to much strain on systems.
-It is intended for getting in-sync with the server, or to get a list of all tokens (from a server without push) every X hours.
+It is intended for getting in-sync with the server, or to get a list of all tokens (from a server without Push mode) every X hours.
 
 [[mod_tokens_real-time_authorization]]
 ==== Real-time authorization
@@ -45,7 +45,7 @@ If an eMSP doesn't want real-time authorization, the <<mod_tokens_post_method,PO
 [[mod_tokens_interfaces_and_endpoints]]
 === Interfaces and endpoints
 
-There is both a CPO and an eMSP interface for Tokens. It is advised to use the push direction from eMSP to CPO during normal operation.
+There is both a CPO and an eMSP interface for Tokens. It is advised to use the Push direction from eMSP to CPO during normal operation.
 The eMSP interface is meant to be used when the CPO is not 100% sure the Token cache is still correct.
 
 [[mod_tokens_cpo_interface]]

--- a/mod_tokens.asciidoc
+++ b/mod_tokens.asciidoc
@@ -52,7 +52,7 @@ The eMSP interface is meant to be used when the CPO is not 100% sure the Token c
 ==== CPO Interface
 
 With this interface the eMSP can push the Token information to the CPO.
-Tokens is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,client owned object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
+Tokens is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 
 Endpoint structure definition:
 

--- a/status_codes.asciidoc
+++ b/status_codes.asciidoc
@@ -2,22 +2,24 @@
 == Status codes
 
 There are two types of status codes:
+
 - Transport related (HTTP)
 - Content related (OCPI)
 
 The transport layer ends after a message is correctly parsed into a (semantically unvalidated) JSON structure.
-When a message does not contain a valid JSON string, the HTTP error `400 - Bad request` is returned.
+When a message does not contain a valid JSON string, the HTTP error `400 - Bad request` MUST be returned.
 
-If a request is syntactically valid JSON and addresses an existing resource, no HTTP error should be returned.
-Those requests are supposed to have reached the OCPI layer. As is customary for RESTful APIs:
-if the resource does NOT exist, the server should return a HTTP `404 - Not Found`.
+If a request is syntactically valid JSON and addresses an existing resource, a HTTP error MUST NOT be returned.
+Those requests are supposed to have reached the OCPI layer. 
 
-When the server receives a valid OCPI object it should respond with:
+If the requested resource does NOT exist, the server SHOULD return a HTTP `404 - Not Found`.
 
-* HTTP `200 - Ok` when the object already existed and is successfully updated.
-* HTTP `201 - Created` when the object is newly created in the server system.
+When the server receives a valid OCPI object it SHOULD respond with:
 
-Requests that reach the OCPI layer should return an OCPI response message with a `status_code` field as defined below.
+* HTTP `200 - Ok` when the object already existed and has successfully been updated.
+* HTTP `201 - Created` when the object has been newly created in the server system.
+
+Requests that reach the OCPI layer SHOULD return an OCPI response message with a `status_code` field as defined below.
 
 [cols="3,10",options="header"]
 |===
@@ -28,7 +30,7 @@ Requests that reach the OCPI layer should return an OCPI response message with a
 |3xxx |Server errors – The server encountered an internal error 
 |===
 
-When the status code is in the success range (1xxx), the `data` field in the response message should contain the information as specified in the protocol. Otherwise the `data` field is unspecified and may be omitted, `null` or something else that could help to debug the problem from a programmer's perspective. For example, it could specify which fields contain an error or are missing.
+When the status code is in the success range (1xxx), the `data` field in the response message SHOULD contain the information as specified in the protocol. Otherwise the `data` field is unspecified and MAY be omitted, set to `null` or something else that could help to debug the problem from a programmer's perspective. For example, it could specify which fields contain an error or are missing.
 
 [[status_codes_1xxx_success]]
 === 1xxx: Success
@@ -43,7 +45,7 @@ When the status code is in the success range (1xxx), the `data` field in the res
 [[status_codes_2xxx_client_errors]]
 === 2xxx: Client errors
 
-Errors detected by a server in the message sent by a client: The client did something wrong
+Errors detected by the server in the message sent by a client where the client did something wrong.
 
 [cols="3,10",options="header"]
 |===
@@ -66,24 +68,24 @@ Error during processing of the OCPI payload in the server. The message was synta
 
 |3000 |Generic server error 
 |3001 |Unable to use the client's API. For example during the credentials registration: When the initializing party requests data from the other party during the open POST call to its credentials endpoint. If one of the GETs can not be processed, the party should return this error in the POST response. 
-|3002 |Unsupported version. 
-|3003 |No matching endpoints or expected endpoints missing between parties. Used during the registration process if the two parties do not have any mutual modules or endpoints available, or the minimum expected by the other party implementation. 
+|3002 |Unsupported version 
+|3003 |No matching endpoints or expected endpoints missing between parties. Used during the registration process if the two parties do not have any mutual modules or endpoints available, or the minimal implementation expected by the other party is not been met. 
 |===
 
 
 [[status_codes_4xxx_hub_errors]]
 === 4xxx: Hub errors
 
-When a server encounters an error, client side error (2xxx) or server side error (3xxx), it is send to status code to the Hub,
-the Hub SHALL forward this error to the client sending the request (when the request was not a broadcast push).
+When a server encounters an error, client side error (2xxx) or server side error (3xxx), it sends the status code to the Hub.
+The Hub SHALL then forward this error to the client which sent the request (when the request was not a Broadcast push).
 
-For errors that a Hub encounters when routing messages, the following OCPI status codes shall be used.
+For errors that a Hub encounters while routing messages, the following OCPI status codes shall be used.
 
 [cols="3,10",options="header"]
 |===
 |Code |Description
 
-|4001 |Unknown receiver (TO address is unknown).
-|4002 |Timeout on forwarded request (Message is forwarded, but request times out.)
-|4003 |Connection problem (Receiving party is not connected)
+|4001 |Unknown receiver (TO address is unknown)
+|4002 |Timeout on forwarded request (message is forwarded, but request times out)
+|4003 |Connection problem (receiving party is not connected)
 |===

--- a/status_codes.asciidoc
+++ b/status_codes.asciidoc
@@ -77,7 +77,7 @@ Error during processing of the OCPI payload in the server. The message was synta
 === 4xxx: Hub errors
 
 When a server encounters an error, client side error (2xxx) or server side error (3xxx), it sends the status code to the Hub.
-The Hub SHALL then forward this error to the client which sent the request (when the request was not a Broadcast push).
+The Hub SHALL then forward this error to the client which sent the request (when the request was not a Broadcast Push).
 
 For errors that a Hub encounters while routing messages, the following OCPI status codes shall be used.
 

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -64,7 +64,7 @@ It is therefor advised to clients 'pulling' lists from a server to do this on a 
 [[transport_and_format_request_format]]
 ==== Request format
 
-The request method can be any of <<transport_and_format_get,GET>>, <<transport_and_format_put,PUT>>, <<transport_and_format_patch,PATCH>> or DELETE. The OCPI protocol uses them in a way similar to REST APIs.
+The request method can be any of <<transport_and_format_get,GET>>, POST, <<transport_and_format_put,PUT>>, <<transport_and_format_patch,PATCH>> or DELETE. The OCPI protocol uses them in a way similar to REST APIs.
 
 [cols="2,12",options="header"]
 |===
@@ -312,38 +312,38 @@ include::examples/transport_and_format_get_token_list_example.json[]
 
 When developement of OCPI was started, it was designed for peer-to-peer communication between CPO and eMSP.
 This has advantages, but also disadvantages. Having to setup and maintain OCPI connections to a lot of parties requires more effort then doing for only a couple of connections.
-By communication via one or more Hubs, the amount of OCPI connections is limited, while still being able to offer roaming to a lot of different parties to customers.
+By communication via one or more Hubs, the amount of OCPI connections is reduced, while still being able to offer roaming to a lot of different parties and customers.
 
 With the introduction of Message Routing, OCPI is now better usable for communication via Hubs.
-With this same functionality is also becomes possible to implement virtual CPO/eMSPs.
-A Virtual party is a party that does not has its own back-office, but relies on another parties IT systems.
+With this same functionality it also becomes possible to implement virtual CPO/eMSPs.
+A virtual party is a party that does not have its own back-office, but relies on another parties IT systems.
 This is sometimes also called white-label CPO/eMSP.
 
-When OCPI is used to communicatie via a Hub or to a virtual CPO/eMSP the following 4 HTTP headers can be used, in requests and responses.
+When OCPI is used to communicatie via a Hub or to a virtual CPO/eMSP, the following 4 HTTP headers can be used in requests and responses.
 
 [cols="4,14",options="header"]
 |===
 |HTTP Header |Description
 
-|OCPI-to-party-id |'party id' of the connected party this messages is to be send to.
-|OCPI-to-country-code |'country code' of the connected party this messages is to be send to.
-|OCPI-from-party-id |'party id' of the connected party this messages is send from.
-|OCPI-from-country-code |'country code' of the connected party this messages is send from.
+|OCPI-to-party-id |'party id' of the connected party this message is to be sent to.
+|OCPI-to-country-code |'country code' of the connected party this message is to be sent to.
+|OCPI-from-party-id |'party id' of the connected party this message is sent from.
+|OCPI-from-country-code |'country code' of the connected party this message is sent from.
 |===
 
 .Example sequence diagram of a GET for 1 Object from a CPO to an eMSP.
 image::images/sd_get_simple.svg[OCPI Sequence Diagram Hub GET]
 
 .Example sequence diagram of a PUT via 2 Hubs.
-image::images/sd_put_2_hubs.svg[OCPI Sequence Diagram Hub PUT with 2 hubs]
+image::images/sd_put_2_hubs.svg[OCPI Sequence Diagram Hub PUT with 2 Hubs]
 
 
 ===== Omitting from address in responses
 
-When a party responses to a request (via a hub), and it was a request that contained the 'OCPI-to-' headers,
-the 'OCPI-from-' headers might be omitted. The requesting party knows to which party the request was send.
-It might be good practice to always provide the 'OCPI-from-' headers in a response,
-just to be complete and to give a requesting party to change to validate if the request was routed correctly by the Hub.
+When a party responds to a request (via a Hub), and it has been a request that contained the 'OCPI-to-' header,
+the 'OCPI-from-' header MAY be omitted. The requesting party knows to which party the request was sent.
+It might be good practice to always provide the 'OCPI-from-' header in a response though,
+just to be complete and to give the requesting party a chance to validate if the request has been routed correctly by the Hub.
 
 
 [[transport_and_format_message_routing_broadcast_push]]
@@ -351,28 +351,30 @@ just to be complete and to give a requesting party to change to validate if the 
 
 For simplicity, connected clients might PUSH (POST, PUT, PATCH) information to all connected clients with an "opposite role",
 CPO pushing information to all eMSPs and NSPs. eMSP pushing information to all CPOs.
-(the role "Other" is seen as an eMSP type of role, so broadcast push from a CPO is also send to Other,
-messages from "Other" are send to CPOs, not the eMSPs.)
+(The role "Other" is seen as an eMSP type of role, so broadcast push from a CPO is also sent to "Other".
+Messages from "Other" are only sent to CPOs and not to eMSPs though.)
 
-Broadcast push might be very useful to push information like Locations or Tokens to all parties,
+Broadcast pushing data through a Hub might be very useful to share information like Locations or Tokens with all parties
 connected to the Hub that have implemented the corresponding module.
-This means only 1 request to the Hub, not having to worry about the number of connected clients.
+This means only one request to the Hub will be necessary, as all connected clients will be served by the Hub.
+In other words: the Hub broadcasts received information to all connected clients.
 
-To send a Broadcast push, the client uses to Hubs party-id and country-code in the 'OCPI-to-' headers.
-The Hub parses the request and sends a response to the client, with optionally its own party-id and country-code in the 'OCPI-from-' headers.
-The Hub then sends the push to any client implementing the applicable module, using its own party-id and country-code in the 'OCPI-from-' headers.
-The client receiving a push from a Hub (with the Hubs information in the 'OCPI-from-' headers) will respond to
-this push with the Hubs party-id and country-code in the 'OCPI-to-' headers.
+To send a broadcast push, the client uses the party-id and country-code of the Hub in the 'OCPI-to-' header.
+The Hub parses the request and sends a response to the client, which optionally contains its own party-id and country-code in the 'OCPI-from-' header.
+The Hub then sends the pushed data to any client implementing the corresponding applicable module, using its own party-id and country-code in the 'OCPI-from-' header.
+The client receiving a PUSH from a Hub (with the Hubs information in the 'OCPI-from-' header) will respond to
+this PUSH with the Hubs party-id and country-code in the 'OCPI-to-' header.
 
-GET SHALL NOT be used in combination with Broadcast push.
+GET SHALL NOT be used in combination with broadcast pushing.
 If the requesting party wants to GET information of which it does not know the receiving party,
-to <<transport_and_format_message_routing_open_routing_request,Open routing request>> MUST be used. (see below)
+an <<transport_and_format_message_routing_open_routing_request,open routing request>> MUST be used. (see below)
 
-Broadcast push SHALL only be used with information that is meant to be send to all other parties. It is useful for things like:
+Broadcast pushing SHALL only be used with information that is meant to be sent to all other parties. It is useful to share data like
 <<mod_tokens.asciidoc#mod_tokens_tokens_module,Tokens>> and <<mod_locations.asciidoc#mod_locations_locations_module,Locations>>,
-but not for <<mod_cdrs.asciidoc#mod_cdrs_cdrs_module,CDRs>> and <<mod_sessions.asciidoc#mod_sessions_sessions_module,Sessions>>.
+but not so much for <<mod_cdrs.asciidoc#mod_cdrs_cdrs_module,CDRs>> and <<mod_sessions.asciidoc#mod_sessions_sessions_module,Sessions>>
+as these pieces of information are specific to only one party and are possibly even protected by GDPR or other laws.
 
-NOTE: For "Client owned objects" the party-id and country-code in the URL segments will still be the original party-id and country-code from the original client sending the Broadcast push to the Hub.
+NOTE: For "client owned objects", the party-id and country-code in the URL segments will still be the original party-id and country-code from the original client sending the Broadcast push to the Hub.
 
 .Example sequence diagram of a broadcast PUT from a CPO to multiple eMSPs.
 image::images/sd_put_boardcast.svg[OCPI Sequence Diagram Hub PUT]
@@ -380,13 +382,13 @@ image::images/sd_put_boardcast.svg[OCPI Sequence Diagram Hub PUT]
 
 [[transport_and_format_message_routing_open_routing_request]]
 ===== Open routing request
-When a Hub has the intelligence to route messages, based on the content of the request,
-or the requesting party does not know the destination of a request, the 'OCPI-to-' headers can be omitted in the request towards a hub.
-The Hub can then decide to which part a request needs to be routed, or that it needs to be broadcasted.
+When a Hub has the intelligence to route messages based on the content of the request,
+or the requesting party does not know the destination of a request, the 'OCPI-to-' header can be omitted in the request towards the Hub.
+The Hub can then decide to which party a request needs to be routed, or that it needs to be broadcasted if the destination cannot be determined.
 
-This is not a derived/sub-version version of <<transport_and_format_message_routing_broadcast_push,Broadcast push>>,
-<<transport_and_format_message_routing_broadcast_push,Broadcast push>> is only for the 'push' <<transport_and_format_pull_and_push,model>>,
-so not for <<transport_and_format_get,GET>> requests.
+This has nothing to do with <<transport_and_format_message_routing_broadcast_push,Broadcast push>> though,
+as <<transport_and_format_message_routing_broadcast_push,Broadcast push>> only works for the 'push' <<transport_and_format_pull_and_push,model>>,
+not for <<transport_and_format_get,GET>> requests.
 
 Open routing requests are possible for GET (<<transport_and_format_get_all_for_hub_not_possible,Not GET ALL>>), POST, PUT, PATCH and DELETE.
 
@@ -396,36 +398,36 @@ image::images/sd_get_openrouting.svg[OCPI Sequence Diagram Hub GET]
 [[transport_and_format_get_all_for_hub_not_possible]]
 ====== GET All not possible via Hubs
 It is not possible for a client to ask the Hub for all objects within a certain module from all other parties.
-This is also the case for a ?? TODO Name for CPO/eMSP Service Providers
+This is also the case for a ?? TODO Name for CPO/eMSP Service Providers.
 
-When the Hub would combine the objects of different parties in one response, that response will only contain one set of routing headers.
-Which will result in the client being unable to determine which object belongs to which party.
+When the Hub would combine the objects of different parties in one response, the response would also only contain one set of routing headers,
+which would result in the client being unable to determine which objects belong to which party.
 
 Examples:
 
-- A eMSP cannot ask the Hub for all the Locations the hub knows from all connected CPOs.
-- A CPO cannot ask the Hub for all the Tokens a hub knows from all connected eMSPs.
+- An eMSP cannot ask the Hub for all the Locations the Hub knows from all connected CPOs.
+- A CPO cannot ask the Hub for all the Tokens a Hub knows from all connected eMSPs.
 
-The Tokens example: When the Hub would combine all the Tokens it knows and return them in one (paginated) response to the client,
-there will be Tokens from different eMSPs in the same response, but there can only be one set of 'OCPI-from-' headers,
-which means the CPO cannot determine which Token belongs to which (virtual) eMSP.
+To elaborate on the Tokens example: When the Hub would combine all the Tokens it knows and returned them in one (paginated) response to the client,
+there would be Tokens from different eMSPs in the same response. But as there can only be one 'OCPI-from-' header,
+the CPO would not be able to determine which Token belongs to which (virtual) eMSP.
 
 
 ===== Overview of required/optional routing headers for different scenarios
 
-The following sections shows which headers are required/optional to be used, and which 'OCPI-to-'/OCPI-from-' IDs need to be used.
+The following section shows which headers are required/optional and which 'OCPI-to-'/'OCPI-from-' IDs need to be used.
 
 This is not an exclusive list, combinations are possible.
 
-When the hub sends something to a virtual-party, the 'OCPI-to-' headers are required.
+When the Hub sends something to a virtual-party, the 'OCPI-to-' header is required.
 
-When the hub receives something from a virtual-party, the 'OCPI-from-' headers are required.
+When the Hub receives something from a virtual-party, the 'OCPI-from-' header is required.
 
 
-====== Virtual-party to virtual-party (without hub)
+====== Virtual-party to virtual-party (without Hub)
 
-This table contains the description of which headers are required to be used for which message when a request is
-directly send from one platform provider to another platform provider for the virtual parties they provides services for, without a hub in between.
+This table contains the description of which headers are required to be used for which message when a request is sent
+directly from one platform provider to another platform provider for the virtual parties they provide services for, without a Hub in between.
 
 [cols="8,10,8,8",options="header"]
 |===
@@ -445,22 +447,22 @@ This table contains the description of which headers are required to be used for
 [cols="8,10,8,8,10",options="header"]
 |===
 | Name | Route | TO Header | FROM Header | Description
-| Direct request | Requesting party to Hub | Receiving-party | | FROM headers are optional, Hub knows the requesting party
-| Direct request | Hub to receiving party | | Requesting-party | TO headers are optional, party knows this request is for the party itself.
-| Direct response | receiving party to Hub | Requesting-party | | FROM headers are optional, Hub knows the responding party
-| Direct response | Hub to requesting party | | Receiving-party | TO headers are optional, party knows this response is for the party itself.
+| Direct request | Requesting party to Hub | Receiving-party | | FROM header is optional, Hub knows the requesting party.
+| Direct request | Hub to receiving party | | Requesting-party | TO header is optional, party knows this request is for the party itself.
+| Direct response | Receiving party to Hub | Requesting-party | | FROM header is optional, Hub knows the responding party.
+| Direct response | Hub to requesting party | | Receiving-party | TO header is optional, party knows this response is for the party itself.
 |===
 
 ====== Virtual-party to Virtual-Party via Hub
 
-This table contains the description of which header are required to be used for which message when a request is directly routed from a virtual party to a virtual party.
+This table contains the description of which headers are required to be used for which message when a request is directly routed from a virtual party to a virtual party.
 In this scenario all headers are needed because the receiving/sending party is not the virtual-party themselves.
 [cols="8,10,8,8",options="header"]
 |===
 | Name | Route | TO Header | FROM Header | Description
 | Direct request | Requesting party to Hub | Receiving-virtual-party | Requesting-virtual-party
 | Direct request | Hub to receiving party | Receiving-virtual-party | Requesting-virtual-party
-| Direct response | receiving party to Hub | Requesting-virtual-party | Receiving-virtual-party
+| Direct response | Receiving party to Hub | Requesting-virtual-party | Receiving-virtual-party
 | Direct response | Hub to requesting party | Requesting-virtual-party | Receiving-virtual-party
 |===
 
@@ -470,42 +472,42 @@ image::images/sd_virtual_hub_virtual.svg[Example sequence diagram of a GET for 1
 
 ====== Party to Party broadcast push
 
-This table contains the description of which header are required to be used for which message when a request is a
-<<transport_and_format_message_routing_broadcast_push,broadcast push>> to the hub.
+This table contains the description of which headers are required to be used for which message when a request is a
+<<transport_and_format_message_routing_broadcast_push,Broadcast push>> to the Hub.
 [cols="8,10,8,8,10",options="header"]
 |===
 | Name | Route | TO Header | FROM Header | Description
-| Broadcast request | Requesting party to Hub | Hub | | FROM headers are optional, Hub knows the requesting party
-| Broadcast response | Hub to requesting party | | Hub | TO headers are optional, party knows this response is for the party itself.
-| Broadcast request | Hub to receiving party | | Hub | TO headers are optional, party knows this request is for the party itself.
-| Broadcast response | receiving party to Hub | Hub | | FROM headers are optional, Hub knows the responding party
+| Broadcast request | Requesting party to Hub | Hub | | FROM header is optional, Hub knows the requesting party.
+| Broadcast response | Hub to requesting party | | Hub | TO header is optional, party knows this response is for the party itself.
+| Broadcast request | Hub to receiving party | | Hub | TO header is optional, party knows this request is for the party itself.
+| Broadcast response | Receiving party to Hub | Hub | | FROM header is optional, Hub knows the responding party.
 |===
 
 ====== Virtual-party to Virtual-Party broadcast push
 
-This table contains the description of which header are required to be used for which message when a request is to be broadcasted by the hub and both parties are virtual parties.
-For a broadcast, the TO headers in the request from the requesting party to the Hub should contain the information of the Hub.
+This table contains the description of which headers are required to be used for which message when a request is to be broadcasted by the Hub and both parties are virtual parties.
+For a broadcast, the TO header in the request from the requesting party to the Hub should contain the information of the Hub.
 [cols="8,10,8,8",options="header"]
 |===
 | Name | Route | TO Header | FROM Header | Description
 | Broadcast request | Requesting party to Hub | Hub | Requesting-virtual-party
 | Broadcast response | Hub to requesting party | Requesting-virtual-party | Hub
 | Broadcast request | Hub to receiving party | Receiving-virtual-party | Hub
-| Broadcast response | receiving party to Hub | Hub | Receiving-virtual-party
+| Broadcast response | Receiving party to Hub | Hub | Receiving-virtual-party
 |===
 
 
 ====== Party to Party open routing request
 
-This table contains the description of which header are required to be used for which message when a request <<transport_and_format_message_routing_open_routing_request,to be routed by the Hub itself>>.
-For an Open Request, the TO headers in the request from the requesting party to the Hub has to omitted.
+This table contains the description of which headers are required to be used for which message when <<transport_and_format_message_routing_open_routing_request,the routing of a request needs to be determined by the Hub itself>>.
+For an Open routing request, the TO header in the request from the requesting party to the Hub MUST be omitted.
 [cols="8,10,8,8,10",options="header"]
 |===
 | Name | Route | TO Header | FROM Header | Description
-| Open request | Requesting party to Hub | | | Omitting the TO headers indicates to the Hub that the Hub has to figure out the routing.
-| Open request | Hub to receiving party | | Requesting-party | TO headers can be omitted, when the receiving party is NOT a virtual party.
-| Open response | receiving party to Hub | Requesting-party | Receiving-party | FROM headers can be omitted, when the receiving party is NOT a virtual party.
-| Open response | Hub to requesting party | Requesting-party | Receiving-party | TO headers can be omitted, when the requesting party is NOT a virtual party.
+| Open request | Requesting party to Hub | | | Omitting the TO header indicates to the Hub that the Hub has to figure out the routing itself.
+| Open request | Hub to receiving party | | Requesting-party | TO header can be omitted when the receiving party is NOT a virtual party.
+| Open response | Receiving party to Hub | Requesting-party | Receiving-party | FROM header can be omitted when the receiving party is NOT a virtual party.
+| Open response | Hub to requesting party | Requesting-party | Receiving-party | TO header can be omitted when the requesting party is NOT a virtual party.
 |===
 
 
@@ -519,15 +521,15 @@ For debugging issues, OCPI implementations are required to include unique IDs vi
 |HTTP Header |Description
 
 |X-Request-ID     |Every request SHALL contain a unique request ID, the response to this request SHALL contain the same ID.
-|X-Correlation-ID |Every request/response send via a Hub SHALL contain a unique correlation-ID, every response to this request SHALL contain the same ID.
+|X-Correlation-ID |Every request/response sent via a Hub SHALL contain a unique correlation ID, every response to this request SHALL contain the same ID.
 |===
 
 It is advised to used GUID/UUID as values for X-Request-ID and X-Correlation-ID.
 
-When a Hub forwards a request to a party, the request to the other party SHALL a new/unique value in the X-Request-ID HTTP header,
-not copy the X-Request-ID HTTP header from the incoming request that was forwarded.
+When a Hub forwards a request to a party, the request to this party SHALL contain a new unique value in the X-Request-ID HTTP header,
+not a copy of the X-Request-ID HTTP header taken from the incoming request that is being forwarded.
 
-When a Hub forwards a request to a party, the request SHALL contain the same X-Correlation-ID HTTP header (with the same value)
+When a Hub forwards a request to a party, the request SHALL contain the same X-Correlation-ID HTTP header (with the same value).
 
 TODO Add sequence diagram to show how X-Request-ID and X-Correlation-ID work together
 
@@ -562,13 +564,15 @@ The URLs of the endpoints in this document are descriptive only. The exact URL c
 [[transport_and_format_offline_behaviour]]
 === Offline behaviour
 
-During communication over OCPI, it might happen that one of the communication parties is unreachable for an amount of time.
+During communication over OCPI, it might happen that one of the communicating parties is unreachable for an undefined amount of time.
 OCPI works event based, new messages and status are pushed from one party to another. When communication is lost, updates cannot be delivered.
 
-OCPI messages should not be queued. When a client does a POST, PUT or PATCH request and that requests fails or times out,
-the client should not queue the message and retry the same message again on a later time. 
+OCPI messages SHOULD NOT be queued. When a client does a POST, PUT or PATCH request and that request fails or times out,
+the client should not queue the message and retry the same message again later. 
 
-When the connection is re-established, it is up to the target-server of a connection to GET the current status from to source-server to get back in-sync.
+When the connection is re-established, it is up to the target-server of a connection to GET the current status from to source-server in order to get back to a synchronized state.
+
 For example:
-- CDRs of the period of communication loss can be rerieved with a GET command on the CDRs module, with filters to retrieve only CDRs of the period since the last CDR was received.
+
+- CDRs of the period of communication loss can be rerieved with a GET command on the CDRs module, with filters to retrieve only CDRs of the period since the last CDR has been received.
 - Status of EVSEs (or Locations) can be retrieved by calling a GET on the Locations module.

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -211,7 +211,7 @@ The mimetype of the request body is `application/json` and may contain the data 
 In case a PATCH request fails, the client is expected to call the <<transport_and_format_get,GET>> method to check the state of the object in the other party's system. If the object doesn't exist, the client should do a <<transport_and_format_put,PUT>>. 
 
 [[transport_and_format_client_owned_object_push]]
-==== Client owned object push
+==== Client Owned Object push
 
 Normal client/server RESTful services work in a way where the Server is the owner of the objects that are created. The client requests a POST method with an object to the end-point URL. The response send by the server will contain the URL to the new object. The client will request only one server to create a new object, not multiple servers.
 
@@ -221,9 +221,9 @@ For example: the CPO owns the Tariff objects and pushes them to a couple of eMSP
 The distinction between objects from different CPOs/eMSPs is made based on a {<<credentials.asciidoc#credentials_credentials_object,country_code>>} and {<<credentials.asciidoc#credentials_credentials_object,party_id>>}.
 The <<credentials.asciidoc#credentials_credentials_object,country_code>> and <<credentials.asciidoc#credentials_credentials_object,party_id>> of the other party are received during the <<credentials.asciidoc#credentials_credentials_endpoint,credentials>> handshake, so that a server might know the values a client will use in an URL.
 
-Client owned object URL definition: {base-ocpi-url}/{end-point}/{country-code}/{party-id}/{object-id}
+Client Owned Object URL definition: {base-ocpi-url}/{end-point}/{country-code}/{party-id}/{object-id}
 
-Example of a URL to a client owned object
+Example of a URL to a Client Owned Object
 
 [source]
 ----
@@ -240,7 +240,7 @@ To identified the owner of data, the party generating the information that is pr
 [[transport_and_format_errors]]
 ===== Errors
 
-When a client pushes a client owned object, but the {object-id} in the URL is different from the id in the object being pushed. A Server implementation is advised to return an <<status_codes.asciidoc#status_codes_status_codes,OCPI status code>>: <<status_codes.asciidoc#status_codes_status_codes,2001>>.
+When a client pushes a Client Owned Object, but the {object-id} in the URL is different from the id in the object being pushed. A Server implementation is advised to return an <<status_codes.asciidoc#status_codes_status_codes,OCPI status code>>: <<status_codes.asciidoc#status_codes_status_codes,2001>>.
 
 [[transport_and_format_response_format]]
 ==== Response format
@@ -374,7 +374,7 @@ Broadcast Push SHALL only be used with information that is meant to be sent to a
 but not so much for <<mod_cdrs.asciidoc#mod_cdrs_cdrs_module,CDRs>> and <<mod_sessions.asciidoc#mod_sessions_sessions_module,Sessions>>
 as these pieces of information are specific to only one party and are possibly even protected by GDPR or other laws.
 
-NOTE: For "client owned objects", the party-id and country-code in the URL segments will still be the original party-id and country-code from the original client sending the Broadcast Push to the Hub.
+NOTE: For "Client Owned Objects", the party-id and country-code in the URL segments will still be the original party-id and country-code from the original client sending the Broadcast Push to the Hub.
 
 .Example sequence diagram of a broadcast PUT from a CPO to multiple eMSPs.
 image::images/sd_put_boardcast.svg[OCPI Sequence Diagram Hub PUT]

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -340,9 +340,9 @@ image::images/sd_put_2_hubs.svg[OCPI Sequence Diagram Hub PUT with 2 Hubs]
 
 ===== Omitting from address in responses
 
-When a party responds to a request (via a Hub), and it has been a request that contained the 'OCPI-to-' header,
-the 'OCPI-from-' header MAY be omitted. The requesting party knows to which party the request was sent.
-It might be good practice to always provide the 'OCPI-from-' header in a response though,
+When a party responds to a request (via a Hub), and it has been a request that contained the 'OCPI-to-' headers,
+the 'OCPI-from-' headers MAY be omitted. The requesting party knows to which party the request was sent.
+It might be good practice to always provide the 'OCPI-from-' headers in a response though,
 just to be complete and to give the requesting party a chance to validate if the request has been routed correctly by the Hub.
 
 
@@ -359,11 +359,11 @@ connected to the Hub that have implemented the corresponding module.
 This means only one request to the Hub will be necessary, as all connected clients will be served by the Hub.
 In other words: the Hub broadcasts received information to all connected clients.
 
-To send a Broadcast Push, the client uses the party-id and country-code of the Hub in the 'OCPI-to-' header.
-The Hub parses the request and sends a response to the client, which optionally contains its own party-id and country-code in the 'OCPI-from-' header.
-The Hub then sends the pushed data to any client implementing the corresponding applicable module, using its own party-id and country-code in the 'OCPI-from-' header.
-The client receiving a PUSH from a Hub (with the Hubs information in the 'OCPI-from-' header) will respond to
-this PUSH with the Hubs party-id and country-code in the 'OCPI-to-' header.
+To send a Broadcast Push, the client uses the party-id and country-code of the Hub in the 'OCPI-to-' headers.
+The Hub parses the request and sends a response to the client, which optionally contains its own party-id and country-code in the 'OCPI-from-' headers.
+The Hub then sends the pushed data to any client implementing the corresponding applicable module, using its own party-id and country-code in the 'OCPI-from-' headers.
+The client receiving a PUSH from a Hub (with the Hubs information in the 'OCPI-from-' headers) will respond to
+this PUSH with the Hubs party-id and country-code in the 'OCPI-to-' headers.
 
 GET SHALL NOT be used in combination with Broadcast Push.
 If the requesting party wants to GET information of which it does not know the receiving party,
@@ -383,7 +383,7 @@ image::images/sd_put_boardcast.svg[OCPI Sequence Diagram Hub PUT]
 [[transport_and_format_message_routing_open_routing_request]]
 ===== Open routing request
 When a Hub has the intelligence to route messages based on the content of the request,
-or the requesting party does not know the destination of a request, the 'OCPI-to-' header can be omitted in the request towards the Hub.
+or the requesting party does not know the destination of a request, the 'OCPI-to-' headers can be omitted in the request towards the Hub.
 The Hub can then decide to which party a request needs to be routed, or that it needs to be broadcasted if the destination cannot be determined.
 
 This has nothing to do with <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> though,
@@ -409,7 +409,7 @@ Examples:
 - A CPO cannot ask the Hub for all the Tokens a Hub knows from all connected eMSPs.
 
 To elaborate on the Tokens example: When the Hub would combine all the Tokens it knows and returned them in one (paginated) response to the client,
-there would be Tokens from different eMSPs in the same response. But as there can only be one 'OCPI-from-' header,
+there would be Tokens from different eMSPs in the same response. But as there can only be one 'OCPI-from-' headers,
 the CPO would not be able to determine which Token belongs to which (virtual) eMSP.
 
 
@@ -419,9 +419,9 @@ The following section shows which headers are required/optional and which 'OCPI-
 
 This is not an exclusive list, combinations are possible.
 
-When the Hub sends something to a virtual-party, the 'OCPI-to-' header is required.
+When the Hub sends something to a virtual-party, the 'OCPI-to-' headers are required.
 
-When the Hub receives something from a virtual-party, the 'OCPI-from-' header is required.
+When the Hub receives something from a virtual-party, the 'OCPI-from-' headers are required.
 
 
 ====== Virtual-party to virtual-party (without Hub)
@@ -431,7 +431,7 @@ directly from one platform provider to another platform provider for the virtual
 
 [cols="8,10,8,8",options="header"]
 |===
-| Name | Route | TO Header | FROM Header
+| Name | Route | TO Headers | FROM Headers
 | Direct request | Requesting platform provider to Receiving platform provider | Receiving-virtual-party | Requesting-virtual-party
 | Direct response | Receiving platform provider to Requesting platform provider | Requesting-virtual-party | Receiving-virtual-party
 |===
@@ -446,11 +446,11 @@ This table contains the description of which headers are required to be used for
 
 [cols="8,10,8,8,10",options="header"]
 |===
-| Name | Route | TO Header | FROM Header | Description
-| Direct request | Requesting party to Hub | Receiving-party | | FROM header is optional, Hub knows the requesting party.
-| Direct request | Hub to receiving party | | Requesting-party | TO header is optional, party knows this request is for the party itself.
-| Direct response | Receiving party to Hub | Requesting-party | | FROM header is optional, Hub knows the responding party.
-| Direct response | Hub to requesting party | | Receiving-party | TO header is optional, party knows this response is for the party itself.
+| Name | Route | TO Headers | FROM Headers | Description
+| Direct request | Requesting party to Hub | Receiving-party | | FROM headers are optional, Hub knows the requesting party.
+| Direct request | Hub to receiving party | | Requesting-party | TO headers are optional, party knows this request is for the party itself.
+| Direct response | Receiving party to Hub | Requesting-party | | FROM headers are optional, Hub knows the responding party.
+| Direct response | Hub to requesting party | | Receiving-party | TO headers are optional, party knows this response is for the party itself.
 |===
 
 ====== Virtual-party to Virtual-Party via Hub
@@ -459,7 +459,7 @@ This table contains the description of which headers are required to be used for
 In this scenario all headers are needed because the receiving/sending party is not the virtual-party themselves.
 [cols="8,10,8,8",options="header"]
 |===
-| Name | Route | TO Header | FROM Header | Description
+| Name | Route | TO Headers | FROM Headers | Description
 | Direct request | Requesting party to Hub | Receiving-virtual-party | Requesting-virtual-party
 | Direct request | Hub to receiving party | Receiving-virtual-party | Requesting-virtual-party
 | Direct response | Receiving party to Hub | Requesting-virtual-party | Receiving-virtual-party
@@ -476,20 +476,20 @@ This table contains the description of which headers are required to be used for
 <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> to the Hub.
 [cols="8,10,8,8,10",options="header"]
 |===
-| Name | Route | TO Header | FROM Header | Description
-| Broadcast request | Requesting party to Hub | Hub | | FROM header is optional, Hub knows the requesting party.
-| Broadcast response | Hub to requesting party | | Hub | TO header is optional, party knows this response is for the party itself.
-| Broadcast request | Hub to receiving party | | Hub | TO header is optional, party knows this request is for the party itself.
-| Broadcast response | Receiving party to Hub | Hub | | FROM header is optional, Hub knows the responding party.
+| Name | Route | TO Headers | FROM Headers | Description
+| Broadcast request | Requesting party to Hub | Hub | | FROM headers are optional, Hub knows the requesting party.
+| Broadcast response | Hub to requesting party | | Hub | TO headers are optional, party knows this response is for the party itself.
+| Broadcast request | Hub to receiving party | | Hub | TO headers are optional, party knows this request is for the party itself.
+| Broadcast response | Receiving party to Hub | Hub | | FROM headers are optional, Hub knows the responding party.
 |===
 
 ====== Virtual-party to Virtual-Party Broadcast Push
 
 This table contains the description of which headers are required to be used for which message when a request is to be broadcasted by the Hub and both parties are virtual parties.
-For a broadcast, the TO header in the request from the requesting party to the Hub should contain the information of the Hub.
+For a broadcast, the TO headers in the request from the requesting party to the Hub should contain the information of the Hub.
 [cols="8,10,8,8",options="header"]
 |===
-| Name | Route | TO Header | FROM Header | Description
+| Name | Route | TO Headers | FROM Headers | Description
 | Broadcast request | Requesting party to Hub | Hub | Requesting-virtual-party
 | Broadcast response | Hub to requesting party | Requesting-virtual-party | Hub
 | Broadcast request | Hub to receiving party | Receiving-virtual-party | Hub
@@ -500,14 +500,14 @@ For a broadcast, the TO header in the request from the requesting party to the H
 ====== Party to Party open routing request
 
 This table contains the description of which headers are required to be used for which message when <<transport_and_format_message_routing_open_routing_request,the routing of a request needs to be determined by the Hub itself>>.
-For an Open routing request, the TO header in the request from the requesting party to the Hub MUST be omitted.
+For an Open routing request, the TO headers in the request from the requesting party to the Hub MUST be omitted.
 [cols="8,10,8,8,10",options="header"]
 |===
-| Name | Route | TO Header | FROM Header | Description
-| Open request | Requesting party to Hub | | | Omitting the TO header indicates to the Hub that the Hub has to figure out the routing itself.
-| Open request | Hub to receiving party | | Requesting-party | TO header can be omitted when the receiving party is NOT a virtual party.
-| Open response | Receiving party to Hub | Requesting-party | Receiving-party | FROM header can be omitted when the receiving party is NOT a virtual party.
-| Open response | Hub to requesting party | Requesting-party | Receiving-party | TO header can be omitted when the requesting party is NOT a virtual party.
+| Name | Route | TO Headers | FROM Headers | Description
+| Open request | Requesting party to Hub | | | Omitting the TO headers indicates to the Hub that the Hub has to figure out the routing itself.
+| Open request | Hub to receiving party | | Requesting-party | TO headers can be omitted when the receiving party is NOT a virtual party.
+| Open response | Receiving party to Hub | Requesting-party | Receiving-party | FROM headers can be omitted when the receiving party is NOT a virtual party.
+| Open response | Hub to requesting party | Requesting-party | Receiving-party | TO headers can be omitted when the requesting party is NOT a virtual party.
 |===
 
 

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -46,19 +46,19 @@ the server SHALL respond with a HTTP `401 - Unauthorized` status code.
 [[transport_and_format_pull_and_push]]
 ==== Pull and Push
 
-OCPI supports both 'pull' and 'push' models. 
+OCPI supports both *Pull* and *Push* models. 
 
-* Push: Changes in objects, and new objects are send (semi) real-time to receiver.
-* Pull: Receiver request a (full) list of objects every X times.
+* *Push:* Changes in objects, and new objects are send (semi) real-time to receiver.
+* *Pull:* Receiver request a (full) list of objects every X times.
 
-OCPI doesn't require parties to implement 'push'.
-'pull' is required, a receiver needs to be able to get 'in-sync' after a period of connection loss.
+OCPI doesn't require parties to implement Push.
+Pull is required, a receiver needs to be able to get _in-sync_ after a period of connection loss.
 
-It is possible to implement a 'pull' only OCPI implementation, it might be a good starting point for an OCPI implementation.
-However, it is strongly advised to implement 'push' for production systems that have to handle some load,
+It is possible to implement a Pull only OCPI implementation, it might be a good starting point for an OCPI implementation.
+However, it is strongly advised to implement Push for production systems that have to handle some load,
 especially when a number of clients are requesting long lists frequently.
-'Push' implementation tend to use much less resources.
-It is therefor advised to clients 'pulling' lists from a server to do this on a relative low polling interval: think in hours, not minutes, and to introduce some splay (randomize the length of the poll interface a bit). 
+Push implementation tend to use much less resources.
+It is therefor advised to clients _pulling_ lists from a server to do this on a relative low polling interval: think in hours, not minutes, and to introduce some splay (randomize the length of the poll interface a bit). 
 
 
 [[transport_and_format_request_format]]
@@ -211,7 +211,7 @@ The mimetype of the request body is `application/json` and may contain the data 
 In case a PATCH request fails, the client is expected to call the <<transport_and_format_get,GET>> method to check the state of the object in the other party's system. If the object doesn't exist, the client should do a <<transport_and_format_put,PUT>>. 
 
 [[transport_and_format_client_owned_object_push]]
-==== Client Owned Object push
+==== Client Owned Object Push
 
 Normal client/server RESTful services work in a way where the Server is the owner of the objects that are created. The client requests a POST method with an object to the end-point URL. The response send by the server will contain the URL to the new object. The client will request only one server to create a new object, not multiple servers.
 
@@ -349,7 +349,7 @@ just to be complete and to give the requesting party a chance to validate if the
 [[transport_and_format_message_routing_broadcast_push]]
 ===== Broadcast Push
 
-For simplicity, connected clients might PUSH (POST, PUT, PATCH) information to all connected clients with an "opposite role",
+For simplicity, connected clients might push (POST, PUT, PATCH) information to all connected clients with an "opposite role",
 CPO pushing information to all eMSPs and NSPs. eMSP pushing information to all CPOs.
 (The role "Other" is seen as an eMSP type of role, so Broadcast Push from a CPO is also sent to "Other".
 Messages from "Other" are only sent to CPOs and not to eMSPs though.)
@@ -362,8 +362,8 @@ In other words: the Hub broadcasts received information to all connected clients
 To send a Broadcast Push, the client uses the party-id and country-code of the Hub in the 'OCPI-to-' headers.
 The Hub parses the request and sends a response to the client, which optionally contains its own party-id and country-code in the 'OCPI-from-' headers.
 The Hub then sends the pushed data to any client implementing the corresponding applicable module, using its own party-id and country-code in the 'OCPI-from-' headers.
-The client receiving a PUSH from a Hub (with the Hubs information in the 'OCPI-from-' headers) will respond to
-this PUSH with the Hubs party-id and country-code in the 'OCPI-to-' headers.
+The client receiving a Push from a Hub (with the Hubs information in the 'OCPI-from-' headers) will respond to
+this Push with the Hubs party-id and country-code in the 'OCPI-to-' headers.
 
 GET SHALL NOT be used in combination with Broadcast Push.
 If the requesting party wants to GET information of which it does not know the receiving party,
@@ -387,7 +387,7 @@ or the requesting party does not know the destination of a request, the 'OCPI-to
 The Hub can then decide to which party a request needs to be routed, or that it needs to be broadcasted if the destination cannot be determined.
 
 This has nothing to do with <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> though,
-as <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> only works for the 'push' <<transport_and_format_pull_and_push,model>>,
+as <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> only works for the <<transport_and_format_pull_and_push,Push model>>,
 not for <<transport_and_format_get,GET>> requests.
 
 Open Routing Requests are possible for GET (<<transport_and_format_get_all_for_hub_not_possible,Not GET ALL>>), POST, PUT, PATCH and DELETE.

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -367,7 +367,7 @@ this PUSH with the Hubs party-id and country-code in the 'OCPI-to-' headers.
 
 GET SHALL NOT be used in combination with Broadcast Push.
 If the requesting party wants to GET information of which it does not know the receiving party,
-an <<transport_and_format_message_routing_open_routing_request,open routing request>> MUST be used. (see below)
+an <<transport_and_format_message_routing_open_routing_request,Open Routing Request>> MUST be used. (see below)
 
 Broadcast Push SHALL only be used with information that is meant to be sent to all other parties. It is useful to share data like
 <<mod_tokens.asciidoc#mod_tokens_tokens_module,Tokens>> and <<mod_locations.asciidoc#mod_locations_locations_module,Locations>>,
@@ -381,7 +381,7 @@ image::images/sd_put_boardcast.svg[OCPI Sequence Diagram Hub PUT]
 
 
 [[transport_and_format_message_routing_open_routing_request]]
-===== Open routing request
+===== Open Routing Request
 When a Hub has the intelligence to route messages based on the content of the request,
 or the requesting party does not know the destination of a request, the 'OCPI-to-' headers can be omitted in the request towards the Hub.
 The Hub can then decide to which party a request needs to be routed, or that it needs to be broadcasted if the destination cannot be determined.
@@ -390,7 +390,7 @@ This has nothing to do with <<transport_and_format_message_routing_broadcast_pus
 as <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> only works for the 'push' <<transport_and_format_pull_and_push,model>>,
 not for <<transport_and_format_get,GET>> requests.
 
-Open routing requests are possible for GET (<<transport_and_format_get_all_for_hub_not_possible,Not GET ALL>>), POST, PUT, PATCH and DELETE.
+Open Routing Requests are possible for GET (<<transport_and_format_get_all_for_hub_not_possible,Not GET ALL>>), POST, PUT, PATCH and DELETE.
 
 .Example sequence diagram of a open routing GET from a CPO via the Hub.
 image::images/sd_get_openrouting.svg[OCPI Sequence Diagram Hub GET]
@@ -497,10 +497,10 @@ For a broadcast, the TO headers in the request from the requesting party to the 
 |===
 
 
-====== Party to Party open routing request
+====== Party to Party Open Routing Request
 
 This table contains the description of which headers are required to be used for which message when <<transport_and_format_message_routing_open_routing_request,the routing of a request needs to be determined by the Hub itself>>.
-For an Open routing request, the TO headers in the request from the requesting party to the Hub MUST be omitted.
+For an Open Routing Request, the TO headers in the request from the requesting party to the Hub MUST be omitted.
 [cols="8,10,8,8,10",options="header"]
 |===
 | Name | Route | TO Headers | FROM Headers | Description

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -347,34 +347,34 @@ just to be complete and to give the requesting party a chance to validate if the
 
 
 [[transport_and_format_message_routing_broadcast_push]]
-===== Broadcast push
+===== Broadcast Push
 
 For simplicity, connected clients might PUSH (POST, PUT, PATCH) information to all connected clients with an "opposite role",
 CPO pushing information to all eMSPs and NSPs. eMSP pushing information to all CPOs.
-(The role "Other" is seen as an eMSP type of role, so broadcast push from a CPO is also sent to "Other".
+(The role "Other" is seen as an eMSP type of role, so Broadcast Push from a CPO is also sent to "Other".
 Messages from "Other" are only sent to CPOs and not to eMSPs though.)
 
-Broadcast pushing data through a Hub might be very useful to share information like Locations or Tokens with all parties
+Using Broadcast Push to send data through a Hub might be very useful to share information like Locations or Tokens with all parties
 connected to the Hub that have implemented the corresponding module.
 This means only one request to the Hub will be necessary, as all connected clients will be served by the Hub.
 In other words: the Hub broadcasts received information to all connected clients.
 
-To send a broadcast push, the client uses the party-id and country-code of the Hub in the 'OCPI-to-' header.
+To send a Broadcast Push, the client uses the party-id and country-code of the Hub in the 'OCPI-to-' header.
 The Hub parses the request and sends a response to the client, which optionally contains its own party-id and country-code in the 'OCPI-from-' header.
 The Hub then sends the pushed data to any client implementing the corresponding applicable module, using its own party-id and country-code in the 'OCPI-from-' header.
 The client receiving a PUSH from a Hub (with the Hubs information in the 'OCPI-from-' header) will respond to
 this PUSH with the Hubs party-id and country-code in the 'OCPI-to-' header.
 
-GET SHALL NOT be used in combination with broadcast pushing.
+GET SHALL NOT be used in combination with Broadcast Push.
 If the requesting party wants to GET information of which it does not know the receiving party,
 an <<transport_and_format_message_routing_open_routing_request,open routing request>> MUST be used. (see below)
 
-Broadcast pushing SHALL only be used with information that is meant to be sent to all other parties. It is useful to share data like
+Broadcast Push SHALL only be used with information that is meant to be sent to all other parties. It is useful to share data like
 <<mod_tokens.asciidoc#mod_tokens_tokens_module,Tokens>> and <<mod_locations.asciidoc#mod_locations_locations_module,Locations>>,
 but not so much for <<mod_cdrs.asciidoc#mod_cdrs_cdrs_module,CDRs>> and <<mod_sessions.asciidoc#mod_sessions_sessions_module,Sessions>>
 as these pieces of information are specific to only one party and are possibly even protected by GDPR or other laws.
 
-NOTE: For "client owned objects", the party-id and country-code in the URL segments will still be the original party-id and country-code from the original client sending the Broadcast push to the Hub.
+NOTE: For "client owned objects", the party-id and country-code in the URL segments will still be the original party-id and country-code from the original client sending the Broadcast Push to the Hub.
 
 .Example sequence diagram of a broadcast PUT from a CPO to multiple eMSPs.
 image::images/sd_put_boardcast.svg[OCPI Sequence Diagram Hub PUT]
@@ -386,8 +386,8 @@ When a Hub has the intelligence to route messages based on the content of the re
 or the requesting party does not know the destination of a request, the 'OCPI-to-' header can be omitted in the request towards the Hub.
 The Hub can then decide to which party a request needs to be routed, or that it needs to be broadcasted if the destination cannot be determined.
 
-This has nothing to do with <<transport_and_format_message_routing_broadcast_push,Broadcast push>> though,
-as <<transport_and_format_message_routing_broadcast_push,Broadcast push>> only works for the 'push' <<transport_and_format_pull_and_push,model>>,
+This has nothing to do with <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> though,
+as <<transport_and_format_message_routing_broadcast_push,Broadcast Push>> only works for the 'push' <<transport_and_format_pull_and_push,model>>,
 not for <<transport_and_format_get,GET>> requests.
 
 Open routing requests are possible for GET (<<transport_and_format_get_all_for_hub_not_possible,Not GET ALL>>), POST, PUT, PATCH and DELETE.
@@ -470,10 +470,10 @@ In this scenario all headers are needed because the receiving/sending party is n
 image::images/sd_virtual_hub_virtual.svg[Example sequence diagram of a GET for 1 Object from a Virtual CPO to Virtual MSP via a Hub]
 
 
-====== Party to Party broadcast push
+====== Party to Party Broadcast Push
 
 This table contains the description of which headers are required to be used for which message when a request is a
-<<transport_and_format_message_routing_broadcast_push,Broadcast push>> to the Hub.
+<<transport_and_format_message_routing_broadcast_push,Broadcast Push>> to the Hub.
 [cols="8,10,8,8,10",options="header"]
 |===
 | Name | Route | TO Header | FROM Header | Description
@@ -483,7 +483,7 @@ This table contains the description of which headers are required to be used for
 | Broadcast response | Receiving party to Hub | Hub | | FROM header is optional, Hub knows the responding party.
 |===
 
-====== Virtual-party to Virtual-Party broadcast push
+====== Virtual-party to Virtual-Party Broadcast Push
 
 This table contains the description of which headers are required to be used for which message when a request is to be broadcasted by the Hub and both parties are virtual parties.
 For a broadcast, the TO header in the request from the requesting party to the Hub should contain the information of the Hub.

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -33,7 +33,7 @@ To prevent confusion, when talking about the token used here in the HTTP Authori
 Its parameter is a string consisting of printable, non-whitespace ASCII characters.
 
 The credentials token must uniquely identify the requesting party.
-This way, the server can use the information in the Authorization header to the link the request to the correct requesting party's account.
+This way, the server can use the information in the Authorization header to link the request to the correct requesting party's account.
 
 If the header is missing or the credentials token doesn't match any known party then the server SHALL respond with a HTTP `401 - Unauthorized` status code.
 

--- a/version_information_endpoint.asciidoc
+++ b/version_information_endpoint.asciidoc
@@ -2,9 +2,9 @@
 [[versions_module]]
 == _Versions_ module
 
-This is the required base module of OCPI. This is module is the start point for any OCPI connection.
+This is the required base module of OCPI. This module is the starting point for any OCPI connection.
 Via this module, clients can learn <<version_information_endpoint_version_information_endpoint,which versions>>
-of OCPI a server supports, and <<version_information_endpoint_version_details_endpoint,which modules>> it supports for each version of OCPI.
+of OCPI a server supports, and <<version_information_endpoint_version_details_endpoint,which modules>> it supports for each of the versions.
 
 [[version_information_endpoint_version_information_endpoint]]
 === Version information endpoint
@@ -24,11 +24,9 @@ Examples:
 
 `+https://ocpi.server.com/versions+`
 
-The exact URL to the implemented version endpoint should be given (offline) to parties that interface
-with your OCPI implementation, this endpoint is the starting point for discovering locations
-of the different modules and versions of OCPI that have been implemented.
+The exact URL to the implemented version endpoint should be given (offline) to parties that want to communicate with your OCPI implementation.
 
-Both the CPO and the eMSP must have this endpoint.
+Both, CPOs and eMSPs MUST implement such a version endpoint.
 
 [cols="2,12",options="header"]
 |===
@@ -75,11 +73,11 @@ include::examples/versions_info_example.json[]
 === Version details endpoint
 
 Via the version details, the parties can exchange which modules are implemented for a specific version of OCPI,
-which Interface role is implemented, and what the endpoint URL is for this interface.
+which interface role is implemented, and what the endpoint URL is for this interface.
 
-Parties that are both CPO and eMSP (or are a Hub) can implement one version endpoint.
+Parties that are both CPO and eMSP (or a Hub) can implement one version endpoint that covers both roles.
 With the information that is available in the version details, parties don't need to implement a separate endpoint per role (CPO or eMSP) anymore.
-In the reality this means that when a company that is both a CPO and an eMSP connects to another CPO/MSP combination, only one OCPI connection is needed.
+In practice this means that when a company is both a CPO and an eMSP and it connects to another party that implements both interfaces, only one OCPI connection is needed.
 
 NOTE: OCPI 2.2 introduces the role field in the version details.
 Older versions of OCPI do not support this.
@@ -98,7 +96,7 @@ Examples:
 
 This endpoint lists the supported endpoints and their URLs for a specific OCPI version. To notify the other party that the list of endpoints of your current version has changed, you can send a PUT request to the corresponding credentials endpoint (see the credentials chapter).
 
-Both the CPO and the eMSP must have this endpoint.
+Both the CPO and the eMSP MUST implement this endpoint.
 
 [cols="2,12",options="header"]
 |===
@@ -132,7 +130,7 @@ Both the CPO and the eMSP must have this endpoint.
 |url |<<types.asciidoc#types_url_type,URL>> |1 |URL to the endpoint. 
 |===
 
-NOTE: for the `credentials` module the role is not relevant as this module is the same for all roles.
+NOTE: for the `credentials` module, the role is not relevant as this module is the same for all roles.
 
 
 [[version_information_endpoint_interface_role_enum]]
@@ -150,7 +148,8 @@ NOTE: for the `credentials` module the role is not relevant as this module is th
 [[version_information_endpoint_moduleid_enum]]
 ==== ModuleID _enum_
 
-The Module identifiers for each endpoint are in the beginning of each _Module_ chapter. The following table contains the list of modules in this version of OCPI. Most modules (except <<credentials.asciidoc#credentials_credentials_endpoint,Credentials &amp; registration>>) are optional, but there might be dependencies between modules, if so that will be mentioned in the module description.
+The Module identifiers for each endpoint are described in the beginning of each _Module_ chapter. The following table contains the list of modules in this version of OCPI. Most modules (except <<credentials.asciidoc#credentials_credentials_endpoint,Credentials &amp; Registration>>) are optional, but there might be dependencies between modules.
+If there are dependencies between modules, it will be mentioned in the affected module description.
 
 [cols="5,3,10",options="header"]
 |===
@@ -159,7 +158,7 @@ The Module identifiers for each endpoint are in the beginning of each _Module_ c
 |<<mod_cdrs.asciidoc#mod_cdrs_cdrs_module,CDRs>> |cdrs |
 |<<mod_charging_profiles.asciidoc#mod_charging_profiles_module,Charging Profiles>> |chargingprofiles |
 |<<mod_commands.asciidoc#mod_commands_commands_module,Commands>> |commands |
-|<<credentials.asciidoc#credentials_credentials_endpoint,Credentials &amp; registration>> |credentials |Required for all implementations 
+|<<credentials.asciidoc#credentials_credentials_endpoint,Credentials &amp; Registration>> |credentials |Required for all implementations 
 |<<mod_hub_client_info.asciidoc#mod_hub_client_info_module,Hub Client Info>> |hubclientinfo |
 |<<mod_locations.asciidoc#mod_locations_locations_module,Locations>> |locations |
 |<<mod_sessions.asciidoc#mod_sessions_sessions_module,Sessions>> |sessions |
@@ -176,19 +175,19 @@ List of known versions.
 |===
 |Value |Description 
 
-|2.0 |OCPI version 2.0. 
-|2.1 |OCPI version 2.1. (DEPRECATED, do not use, use 2.1.1 instead) 
-|2.1.1 |OCPI version 2.1.1.
-|2.2 |OCPI version 2.2. (this version)
+|2.0 |OCPI version 2.0
+|2.1 |OCPI version 2.1 (DEPRECATED, do not use, use 2.1.1 instead) 
+|2.1.1 |OCPI version 2.1.1
+|2.2 |OCPI version 2.2 (this version)
 |===
 
 [[version_information_endpoint_custom_modules]]
 ===== Custom Modules
 
 Parties are allowed to create custom modules or customized versions of the existing modules.
-For this the <<version_information_endpoint_moduleid_enum,ModuleID enum>> can be extended with additional custom moduleIDs.
+To do so, the <<version_information_endpoint_moduleid_enum,ModuleID enum>> can be extended with additional custom moduleIDs.
 These custom moduleIDs MAY only be sent to parties with which there is an agreement to use a custom module. Do NOT send custom moduleIDs to parties you are not 100% sure will understand the custom moduleIDs.
-It is advised to use a prefix (country_code + party_id) for any custom moduleID, this ensures that the moduleID will not be used for any future module of OCPI.
+It is advised to use a prefix (e.g. country-code + party-id) for any custom moduleID, this ensures that the moduleID will not be used for any future module of OCPI.
 
 For example:
 `nltnm-tokens`
@@ -196,7 +195,7 @@ For example:
 [[version_information_get_endpoint]]
 ==== GET
 
-Fetch information about the supported endpoints and their URLs for this version.
+Fetch information about the supported endpoints and their URLs for this OICP version.
 
 [[version_information_get_details_endpoint_example]]
 ===== Examples

--- a/version_information_endpoint.asciidoc
+++ b/version_information_endpoint.asciidoc
@@ -195,7 +195,7 @@ For example:
 [[version_information_get_endpoint]]
 ==== GET
 
-Fetch information about the supported endpoints and their URLs for this OICP version.
+Fetch information about the supported endpoints and their URLs for this OCPI version.
 
 [[version_information_get_details_endpoint_example]]
 ===== Examples


### PR DESCRIPTION
I started going through the documentation of OCPI 2.2-rc1 and fixed some of the spelling/wording issues I found. I also highlighted some occurences of `should`, `may` or `must` by writing them entirely uppercase where I found them to be important.

Before going further with this, are such contributions actually desired?
I realize that not all of my changes are _very minor spelling/wording alternations_. For example, in `credentials.asciidoc` I added `ISO-3166 alpha-2` as source for country codes as it seems the only logical source to me. One could see this as unwanted constraint, I see it as suggestion of good practice. Therefore I'd appreciate some feedback before going on with what I'm doing so far.