### PR TITLE
Fix spelling mistake in RoleType enum

### DIFF
--- a/mod_hub_client_info.asciidoc
+++ b/mod_hub_client_info.asciidoc
@@ -285,7 +285,7 @@ Each object must contain all required fields. Fields that are not specified may 
 |Value |Description
 
 |CPO   |Charging Point Operator.
-|EMPS  |e-Mobility Service Provider.
+|EMSP  |e-Mobility Service Provider.
 |NSP   |Navigation Service Provider, role like an eMSP (probably only interested in Location information)
 |OTHER |Other role
 |===


### PR DESCRIPTION
This PR fixes a minor spelling mistake of the `RoleType` enum.

As the whole `HubClientInfo` module has been added with v2.2 and there has been no final release of this version yet, it should be no issue changing the spec.