### PR TITLE
OCPI 2.2: Improve Tariff Descriptions

### DIFF
--- a/examples/tariff_18_reservation_with_expire_time.json
+++ b/examples/tariff_18_reservation_with_expire_time.json
@@ -5,10 +5,10 @@
   "currency": "EUR",
   "elements": [{
     "price_components": [{
-      "type": "FLAT",
-      "price": 4.00,
+      "type": "TIME",
+      "price": 6.00,
       "vat": 20.0,
-      "step_size": 1
+      "step_size": 600
     }],
     "restrictions": {
       "reservation": "RESERVATION_EXPIRES"
@@ -16,7 +16,7 @@
   }, {
     "price_components": [{
       "type": "TIME",
-      "price": 2.00,
+      "price": 3.00,
       "vat": 20.0,
       "step_size": 600
     }],

--- a/examples/tariff_3_alt_url.json
+++ b/examples/tariff_3_alt_url.json
@@ -15,7 +15,7 @@
       "type": "ENERGY",
       "price": 0.25,
       "vat": 10.0,
-      "step_size": 1
+      "step_size": 100
     }]
   }],
   "last_updated": "2015-06-29T20:39:09Z"

--- a/examples/tariff_6_025kwh_start_max_price.json
+++ b/examples/tariff_6_025kwh_start_max_price.json
@@ -4,8 +4,8 @@
   "id": "16",
   "currency": "EUR",
   "max_price": {
-    "excl_vat": 25.00,
-    "incl_vat": 27.50
+    "excl_vat": 10.00,
+    "incl_vat": 11.00
   },
   "elements": [{
     "price_components": [{

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -388,7 +388,7 @@ include::examples/tariff_10_025kwh_parking_start.json[]
 [[mod_tariffs_tariff_example_0_25_euro_per_kwh_start_max_price]]
 ====== Tariff example 0.25 euro per kWh + start fee + max price + tariff end date
 
-* Minimum price
+* Maximum price
 [disc]
 ** 10 euro (excl. VAT)
 ** 11 euro (incl. VAT, which is 10%)
@@ -408,9 +408,9 @@ By assigning both, the old and the new tariff ID, they will automatically be rep
 It is not required to update all Locations at the same time, the old tariff can also be removed later.
 
 For a charging session where 50 kWh are charged,
-this tariff will result in costs of 13.00 euro (excl. VAT) or 14.35 euro (incl. VAT).
-If only 30 kWh were charged, the costs would be 10.00 euro (excl. VAT) and 11.00 euro (incl. VAT),
-as the start fee combined with the energy costs would be lower than the defined minimum price.
+this tariff will result in costs of 10.00 euro (excl. VAT) or 11.00 euro (incl. VAT) due to the price limit.
+If only 30 kWh were charged, the costs would be 8.00 euro (excl. VAT) and 8.85 euro (incl. VAT),
+as the start fee combined with the energy costs would be lower than the defined max price.
 
 [source,json]
 ----

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -14,44 +14,44 @@ The Tariffs module gives eMSPs information about the tariffs used by the CPO.
 [[mod_tariffs_push_model]]
 ==== Push model
 
-When the CPO creates a new Tariff they push them to the eMSPs by calling the <<mod_tariffs_put_method,PUT>> on the eMSPs
+When the CPO creates a new Tariff they push them to the eMSPs by calling the <<mod_tariffs_put_method,PUT>> method on the eMSPs
 Tariffs endpoint with the newly created Tariff object.
 
-Any changes to the Tariff(s) in the CPO system can be send to the eMSP system by calling the <<mod_tariffs_put_method,PUT>>
+Any changes to the Tariff(s) in the CPO's system can be sent to the eMSPs systems by calling the <<mod_tariffs_put_method,PUT>>
 method on the eMSPs Tariffs endpoint with the updated Tariff object.
 
 When the CPO deletes a Tariff, they will update the eMSPs systems by calling <<mod_tariffs_delete_method,DELETE>>
-on the eMSPs Tariffs endpoint, with the ID of the Tariff that is deleted.
+on the eMSPs Tariffs endpoint with the ID of the Tariff that was deleted.
 
-When the CPO is not sure about the state or existence of a Tariff object in the eMSPs system, the
-CPO can call the <<mod_tariffs_msp_get_method,GET>> to validate the Tariff object in the eMSP system. 
+When the CPO is not sure about the state or existence of a Tariff object in the system of an eMSP, the
+CPO can use a <<mod_tariffs_msp_get_method,GET>> request to validate the Tariff object in the eMSP's system. 
 
 [[mod_tariffs_pull_model]]
 ==== Pull model
 
 eMSPs who do not support the Push model need to call
-<<mod_tariffs_cpo_get_method,GET>> on the CPOs Tariff endpoint to receive
+<<mod_tariffs_cpo_get_method,GET>> on the CPO's Tariff endpoint to receive
 all Tariffs, replacing the current list of known Tariffs with the newly received list.
 
 [[mod_tariffs_interfaces_and_endpoints]]
-=== Interfaces and endpoints
+=== Interfaces and Endpoints
 
 There is both a Sender and a Receiver interface for Tariffs. Advised is to use the push direction from Sender to Receiver during normal operation.
-The Sender interface is meant to be used when the connection between 2 parties is established to retrieve the current list of Tariffs objects, and when the Receiver is not 100% sure the Tariff cache is still correct.
+The Sender interface is meant to be used when the connection between two parties is established to retrieve the current list of Tariffs objects, and when the Receiver is not 100% sure the Tariff cache is still up-to-date.
 
 [[mod_tariffs_cpo_interface]]
 ==== Sender Interface
 
 Typically implemented by market roles like: CPO.
 
-The Sender Tariffs interface gives the Receiver the ability to request tariffs.
+The Sender's Tariffs interface gives the Receiver the ability to request Tariffs information.
 
 
 [cols="2,12",options="header"]
 |===
 |Method |Description 
 
-|<<mod_tariffs_cpo_get_method,GET>> |Returns Tariff Objects from the CPO, last updated between the {date_from} and {date_to} (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>) 
+|<<mod_tariffs_cpo_get_method,GET>> |Returns Tariff objects from the CPO, last updated between the `{date_from}` and `{date_to}` (<<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>) 
 |POST |n/a 
 |PUT |n/a 
 |PATCH |n/a 
@@ -65,15 +65,15 @@ Fetch information about all Tariffs.
 
 Endpoint structure definition:
 
-`{tariffs_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&[offset={offset}]&[limit={limit}]`
+`{tariffs_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&amp;[offset={offset}]&amp;[limit={limit}]`
 
 Examples:
 
-`+https://www.server.com/ocpi/cpo/2.2/tariffs/?date_from=2019-01-28T12:00:00&date_to=2019-01-29T12:00:00+`
+`+https://www.server.com/ocpi/cpo/2.2/tariffs/?date_from=2019-01-28T12:00:00&amp;date_to=2019-01-29T12:00:00+`
 
 `+https://ocpi.server.com/2.2/tariffs/?offset=50+`
 
-`+https://www.server.com/ocpi/2.2/tariffs/?date_from=2019-01-29T12:00:00&limit=100+`
+`+https://www.server.com/ocpi/2.2/tariffs/?date_from=2019-01-29T12:00:00&amp;limit=100+`
 
 `+https://www.server.com/ocpi/cpo/2.2/tariffs/?offset=50&amp;limit=100+`
 
@@ -82,7 +82,7 @@ Examples:
 ====== Request Parameters
 
 If additional parameters: `{date_from}` and/or `{date_to}` are provided,
-only Tariffs with (`last_updated`) between the given `{date_from}` (including) and `{date_to}` (excluding) will be returned.
+only Tariffs with `last_updated` between the given `{date_from}` (including) and `{date_to}` (excluding) will be returned.
 
 This request is <<transport_and_format.asciidoc#transport_and_format_pagination,paginated>>, it supports the <<transport_and_format.asciidoc#transport_and_format_paginated_request,pagination>> related URL parameters.
 
@@ -101,7 +101,7 @@ This request is <<transport_and_format.asciidoc#transport_and_format_pagination,
 
 The endpoint returns an object with a list of valid Tariffs, the header will contain the <<transport_and_format.asciidoc#transport_and_format_paginated_response,pagination>> related headers.
 
-Any older information that is not specified in the response is considered as no longer valid.
+Any older information that is not specified in the response is considered no longer valid.
 Each object must contain all required fields. Fields that are not specified may be considered as null values.
 
 [cols="4,1,12",options="header"]
@@ -116,11 +116,11 @@ Each object must contain all required fields. Fields that are not specified may 
 
 Typically implemented by market roles like: eMSP and NSP.
 
-Tariffs is a <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Object>>, so the end-points need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
+Tariffs are <<transport_and_format.asciidoc#transport_and_format_client_owned_object_push,Client Owned Objects>>, so the endpoints need to contain the required extra fields: {<<credentials.asciidoc#credentials_credentials_object,party_id>>} and {<<credentials.asciidoc#credentials_credentials_object,country_code>>}.
 
 Endpoint structure definition:
 
-`{tariffs_endpoint_url}{country_code}/{party_id}/{tariff_id}`
+`{tariffs_endpoint_url}/{country_code}/{party_id}/{tariff_id}`
 
 Example:
 
@@ -131,17 +131,18 @@ Example:
 |===
 |Method |Description 
 
-|<<mod_tariffs_msp_get_method,GET>> |Retrieve a Tariff as it is stored in the eMSP system. 
+|<<mod_tariffs_msp_get_method,GET>> |Retrieve a Tariff as it is stored in the eMSP's system. 
 |POST |n/a 
 |<<mod_tariffs_put_method,PUT>> |Push new/updated Tariff object to the eMSP. 
 |PATCH|n/a
-|<<mod_tariffs_delete_method,DELETE>> |Remove Tariff object which is no longer valid 
+|<<mod_tariffs_delete_method,DELETE>> |Remove a Tariff object which is no longer valid. 
 |===
 
 [[mod_tariffs_msp_get_method]]
 ===== *GET* Method
 
-If the CPO wants to check the status of a Tariff in the eMSP system it might GET the object from the eMSP system for validation purposes. The CPO is the owner of the objects, so it would be illogical if the eMSP system had a different status or was missing an object.
+If the CPO wants to check the status of a Tariff in the eMSP's system, it might GET the object from the eMSP's system for validation purposes.
+After all, the CPO is the owner of the object, so it would be illogical if the eMSP's system had a different status or was missing the object entirely.
 
 [[mod_tariffs_msp_get_request_parameters]]
 ====== Request Parameters
@@ -152,8 +153,8 @@ The following parameters can be provided as URL segments.
 |===
 |Parameter |Datatype |Required |Description 
 
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting this PUT to the eMSP system.
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO performing the PUT request on the eMSP's system.
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO performing the PUT request on the eMSP's system.
 |tariff_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Tariff.id of the Tariff object to retrieve.
 |===
 
@@ -177,13 +178,13 @@ New or updated Tariff objects are pushed from the CPO to the eMSP.
 [[mod_tariffs_request_body]]
 ====== Request Body
 
-In the put request the new or updated Tariff object is sent.
+In the PUT request, the new or updated Tariff object is sent in the body.
 
 [cols="4,1,12",options="header"]
 |===
 |Type |Card. |Description 
 
-|<<mod_tariffs_tariff_object,Tariff>> |1 |New or updated Tariff object 
+|<<mod_tariffs_tariff_object,Tariff>> |1 |New or updated Tariff object.
 |===
 
 [[mod_tariffs_msp_put_request_parameters]]
@@ -195,9 +196,9 @@ The following parameters can be provided as URL segments.
 |===
 |Parameter |Datatype |Required |Description 
 
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting this PUT to the eMSP system. This SHALL be the same value as the `country_code` in the Tariff object being pushed
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system. This SHALL be the same value as the `party_id` in the Tariff object being pushed
-|tariff_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Tariff.id of the (new) Tariff object (to replace).
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO performing the PUT request on the eMSP's system. This SHALL be the same value as the `country_code` in the Tariff object being pushed.
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO performing the PUT request on the eMSP's system. This SHALL be the same value as the `party_id` in the Tariff object being pushed.
+|tariff_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Tariff.id of the Tariff object to create or replace.
 |===
 
 [[mod_tariffs_example_new_tariff_2_euro_per_hour]]
@@ -225,8 +226,8 @@ The following parameters can be provided as URL segments.
 |===
 |Parameter |Datatype |Required |Description 
 
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO requesting this PUT to the eMSP system.
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO requesting this PUT to the eMSP system.
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |yes |Country code of the CPO performing the PUT request on the eMSP's system.
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |yes |Party ID (Provider ID) of the CPO performing the PUT request on the eMSP's system.
 |tariff_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |yes |Tariff.id of the Tariff object to delete.
 |===
 
@@ -236,59 +237,59 @@ The following parameters can be provided as URL segments.
 [[mod_tariffs_tariff_object]]
 ==== _Tariff_ Object
 
-A Tariff Object consists of a list of one or more TariffElements, these elements can be used to create complex Tariff structures.
+A Tariff object consists of a list of one or more Tariff Elements, which can be used to create complex Tariff structures.
 
-When the list of elements contains more than 1 element with the same Tariff Dimension (ENERGY/FLAT/TIME etc.),
-than the first Tariff with that Dimension in the list with matching Restrictions will be used.
-When no Tariff with a specific Dimension is found for which the Restrictions match,
-and there is no Tariff in the list with that specific Dimension without restrictions,
+When the list of Tariff Elements contains more than one Element with the same Tariff Dimension (ENERGY/FLAT/TIME etc.),
+than the first Tariff Element with that Dimension in the list with matching Tariff Restrictions will be used.
+When no Tariff Element with a specific Dimension is found for which the Restrictions match,
+and there is no Tariff Element in the list with the given Dimension without Restrictions,
 there will be no costs for that Tariff Dimension.
 
-It is advised to always set a "default" Tariff per Dimension (ENERGY/FLAT/TIME etc.), the last Tariff,
-with a specific Dimension, in the list of elements with no restriction.
-This acts as a fallback when none of the TariffElements, of a specific Dimension,
-before this one, matches the current relevant parameters.
+It is advised to always add a "default" Tariff Element per Dimension (ENERGY/FLAT/TIME etc.).
+This can be achieved by adding a Tariff Element without Restrictions after all other occurrences of the same Dimension
+in the list of Tariff Elements (the order is important).
+Such a Tariff Element will act as fallback when no other Tariff Element of a specific Dimension matches the relevant parameters (Restrictions).
 
-To define a "Free of Charge" Tariff in OCPI, a tariff has to be provided that has a `type` = `FLAT` and `price` = `0.00`.
+To define a "Free of Charge" tariff in OCPI, a Tariff with `type` = `FLAT` and `price` = `0.00` has to be provided.
 See: <<mod_tariffs_free_of_charge_tariff_example,Free of Charge Tariff example>>
 
 [cols="3,2,1,10",options="header"]
 |===
 |Property |Type |Card. |Description 
 
-|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |1 |ISO-3166 alpha-2 country code of the CPO that 'owns' this Tariff.
-|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |1 |CPO ID of the CPO that 'owns' this Tariff (following the ISO-15118 standard).
-|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the tariff within the CPOs platform (and suboperator platforms).
-|currency |<<types.asciidoc#types_string_type,string>>(3) |1 |Currency of this tariff, ISO 4217 Code 
-|type |<<mod_tariffs_tariff_type,TariffType>> |? | Defines what type of tariff this is. This makes it possible to make distinction possible for different <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preferences>>. When omitted, this tariff is valid for all sessions.
-|tariff_alt_text |<<types.asciidoc#types_displaytext_class,DisplayText>> |* |List of multi language alternative tariff info text
-|tariff_alt_url |<<types.asciidoc#types_url_type,URL>> |? |Alternative URL to tariff info 
+|country_code |<<types.asciidoc#types_cistring_type,CiString>>(2) |1 |ISO-3166 alpha-2 country code of the CPO that _owns_ this Tariff.
+|party_id |<<types.asciidoc#types_cistring_type,CiString>>(3) |1 |CPO ID of the CPO that _owns_ this Tariff (following the ISO-15118 standard).
+|id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Uniquely identifies the tariff within the CPO's platform (and suboperator platforms).
+|currency |<<types.asciidoc#types_string_type,string>>(3) |1 |ISO-4217 code of the currency of this tariff.
+|type |<<mod_tariffs_tariff_type,TariffType>> |? | Defines the type of the tariff. This allows for distinction in case of given <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preferences>>. When omitted, this tariff is valid for all sessions.
+|tariff_alt_text |<<types.asciidoc#types_displaytext_class,DisplayText>> |* |List of multi language alternative tariff info texts.
+|tariff_alt_url |<<types.asciidoc#types_url_type,URL>> |? |Alternative URL to tariff information.
 |min_price |<<types.asciidoc#types_price_class,Price>> |? |When this field is set, a Charging Session with this tariff will at least cost this amount.
-      This is different from a `FLAT` fee (Start Tariff, Transaction Fee), such a fee is a fixed amount that has to be payed for any Charging Session.
-      A Minimum price means that when the cost of a Charging Session is lower then this amount, the cost of the Session will be equal to this amount. Also see note below.
-|max_price |<<types.asciidoc#types_price_class,Price>> |? |When this field is set, a Charging Session with this tariff will NOT cost more then this amount. See note below.
-|elements |<<mod_tariffs_tariffelement_class,TariffElement>> |+ |List of tariff elements
+      This is different from a `FLAT` fee (Start Tariff, Transaction Fee), as a `FLAT` fee is a fixed amount that has to be payed for any Charging Session.
+      A minimum price indicates that when the cost of a Charging Session is lower than this amount, the cost of the Session will be equal to this amount. (Also see note below)
+|max_price |<<types.asciidoc#types_price_class,Price>> |? |When this field is set, a Charging Session with this tariff will NOT cost more than this amount. (See note below)
+|elements |<<mod_tariffs_tariffelement_class,TariffElement>> |+ |List of Tariff Elements.
 |start_date_time |<<types.asciidoc#types_datetime_type,DateTime>> |? |The time when this tariff becomes active. Typically used for a new tariff that is already given with the location, before it becomes active. (See note below)
 |end_date_time |<<types.asciidoc#types_datetime_type,DateTime>> |? |The time after which this tariff is no longer valid. Typically used when this tariff is going to be replaced with a different tariff in the near future. (See note below)
 |energy_mix |<<mod_locations.asciidoc#mod_locations_energymix_class,EnergyMix>> |? |Details on the energy supplied with this tariff.
 |last_updated |<<types.asciidoc#types_datetime_type,DateTime>> |1 |Timestamp when this Tariff was last updated (or created). 
 |===
 
-NOTE: `min_price`: As the VAT might be built up of different parts, there might be situations where minimum including VAT is reached earlier or later then then the minimum excluding VAT.
-So as a rule: they both apply:
- - Minimum cost of a Charging Session including VAT can never be lower than the min_price including VAT.
- - Minimum cost of a Charging Session excluding VAT can never be lower than the min_price excluding VAT.
+NOTE: `min_price`: As the VAT might be built up of different parts, there might be situations where minimum cost including VAT is reached earlier or later than the minimum cost excluding VAT.
+So as a rule, they both apply:
+ - The total cost of a Charging Session excluding VAT can never be lower than the `min_price` excluding VAT.
+ - The total cost of a Charging Session including VAT can never be lower than the `min_price` including VAT.
 
-NOTE: `max_price`: As the VAT might be built up of different parts, there might be situations where maximum including VAT is reached earlier or later then then the maximum excluding VAT.
-So as a rule: they both apply:
- - Total cost of a Charging Session including VAT can never be higher than the max_price including VAT.
- - Total cost of a Charging Session excluding VAT can never be higher than the max_price excluding VAT.
+NOTE: `max_price`: As the VAT might be built up of different parts, there might be situations where maximum cost including VAT is reached earlier or later than the maximum cost excluding VAT.
+So as a rule, they both apply:
+ - The total cost of a Charging Session excluding VAT can never be higher than the `max_price` excluding VAT.
+ - The total cost of a Charging Session including VAT can never be higher than the `max_price` including VAT.
 
-NOTE: `start_date_time` and `end_date_time`: When the tariff of a Charge Point (Location) is changed with an ongoing charging session,
-it is common to not switch the tariff until the ongoing session is finished. But this is NOT a rule of OCPI.
-The driver has started charging and might have read the tariff info before charging. When the tariff is then changed during the session,
-the driver might get a bill that is higher then expected.
-
+NOTE: `start_date_time` and `end_date_time`: When the Tariff of a Charge Point (Location) is changed during an ongoing charging session,
+it is common to not switch the Tariff until the ongoing session is finished. But this is NOT a rule of OCPI.
+When charging at a Charge Point, a driver accepts the tariff which is valid when they start their charging session.
+If the Tariff of the Charge Point would change during the charging session,
+the driver might get billed something they didn't agree to when starting the session.
 
 
 [[mod_tariffs_examples]]
@@ -297,9 +298,13 @@ the driver might get a bill that is higher then expected.
 [[mod_tariffs_simple_tariff_example_0_25_euro_per_kwh]]
 ====== Simple Tariff example 0.25 euro per kWh
 
-- 0.25 euro per kWh (excluding VAT)
-- 10% VAT
-- Billed per 1 Wh
+* Energy
+[disc]
+** 0.25 euro per kWh (excl. VAT)
+** 10% VAT
+** Billed per 1 Wh
+
+This tariff will result in costs of 5.00 euro (excl. VAT) or 5.50 euro (incl. VAT) when 20 kWh are charged.
 
 [source,json]
 ----
@@ -312,15 +317,15 @@ include::examples/tariff_8_simple_025kwh.json[]
 
 * Start or transaction fee
 [disc]
-** 0.50 euro (excluding VAT)
+** 0.50 euro (excl. VAT)
 ** 20% VAT
 * Energy
 [disc]
-** 0.25 euro per kWh (excluding VAT)
+** 0.25 euro per kWh (excl. VAT)
 ** 10% VAT
 ** Billed per 1 Wh
 
-This tariff will result in costs of 5.50 euro (ex VAT) when 20 kWh is charged.
+This tariff will result in total cost of 5.50 euro (excl. VAT) or 6.10 euro (incl. VAT) when 20 kWh are charged.
 
 [source,json]
 ----
@@ -331,15 +336,19 @@ include::examples/tariff_9_025kwh_start.json[]
 [[mod_tariffs_tariff_example_0_25_euro_per_kwh_min_price]]
 ====== Tariff example 0.25 euro per kWh + minimum price
 
-* minimum price 0.50 (ex VAT)
-* 0.25 euro per kWh (excluding VAT)
-* 10% VAT
-* Billed per 1 Wh
+* Minimum price
+** 0.50 euro (excl. VAT)
+** 0.55 euro (incl. VAT, which is 10%)
+* Energy
+[disc]
+** 0.25 euro per kWh (excl. VAT)
+** 10% VAT
+** Billed per 1 Wh
 
-This tariff will result in costs of 5.00 euro (ex VAT) when 20 kWh is charged.
-But if less then 2 kWh is charged, 0.50 (ex VAT) will be billed.
+This tariff will result in costs of 5.00 euro (excl. VAT) or 5.50 euro (incl. VAT) when 20 kWh are charged.
+But if less than 2 kWh is charged, 0.50 euro (excl. VAT) or 0.55 euro (incl. VAT) will be billed.
 
-This is different from a start fee, see example above.
+This is different from a start fee as can be seen when compared to the example above.
 
 [source,json]
 ----
@@ -352,18 +361,23 @@ include::examples/tariff_12_025kwh_min_price.json[]
 
 * Start or transaction fee
 [disc]
-** 0.50 euro (excluding VAT)
+** 0.50 euro (excl. VAT)
 ** 20% VAT
 * Energy
 [disc]
-** 0.25 euro per kWh (excluding VAT)
+** 0.25 euro per kWh (excl. VAT)
 ** 10% VAT
 ** Billed per 1 Wh
 * Parking
 [disc]
-** 2.00 euro per hour (excluding VAT)
+** 2.00 euro per hour (excl. VAT)
 ** 20% VAT
 ** Billed per 15 min (900 seconds)
+
+For a charging session where 20 kWh are charged and the vehicle is parked for 40 minutes after the session ended,
+this tariff will result in costs of 7.00 euro (excl. VAT) or 7.90 euro (incl. VAT).
+Because the parking time is billed per 15 minutes, the driver has to pay for 45 minutes of parking even though
+they left 40 minutes after their vehicle stopped charging.
 
 [source,json]
 ----
@@ -374,21 +388,29 @@ include::examples/tariff_10_025kwh_parking_start.json[]
 [[mod_tariffs_tariff_example_0_25_euro_per_kwh_start_max_price]]
 ====== Tariff example 0.25 euro per kWh + start fee + max price + tariff end date
 
+* Minimum price
+[disc]
+** 10 euro (excl. VAT)
+** 11 euro (incl. VAT, which is 10%)
 * Start or transaction fee
 [disc]
-** 0.50 euro (excluding VAT)
+** 0.50 euro (excl. VAT)
 ** 20% VAT
 * Energy
 [disc]
-** 0.25 euro per kWh (excluding VAT)
+** 0.25 euro per kWh (excl. VAT)
 ** 10% VAT
 ** Billed per 1 Wh
 
-This tariff has a maximum price of 25 euro (ex VAT).
+This tariff has an end date: 30 June 2019, which is typically used when a tariff is going to be replaced by a new tariff.
+A <<mod_locations.asciidoc#mod_locations_connector_object,Connector>> of a <<mod_locations.asciidoc#mod_locations_location_object,Location>> can have multiple Tariffs (IDs) assigned.
+By assigning both, the old and the new tariff ID, they will automatically be replaced.
+It is not required to update all Locations at the same time, the old tariff can also be removed later.
 
-This tariff has an end date: 30 June 2019, this is typically used when a tariff is going to be replaced by a new tariff.
-A <<mod_locations.asciidoc#mod_locations_connector_object,Connector>> of a <<mod_locations.asciidoc#mod_locations_location_object,Location>> can have multiple tariffs (IDs).
-By assigning both the old and the new tariff ID, they will automatically be replaced. It is then not need to update all location at the same time, the old tariff can be removed later.
+For a charging session where 50 kWh are charged,
+this tariff will result in costs of 13.00 euro (excl. VAT) or 14.35 euro (incl. VAT).
+If only 30 kWh were charged, the costs would be 10.00 euro (excl. VAT) and 11.00 euro (incl. VAT),
+as the start fee combined with the energy costs would be lower than the defined minimum price.
 
 [source,json]
 ----
@@ -401,11 +423,16 @@ include::examples/tariff_6_025kwh_start_max_price.json[]
 
 An example of a tariff where the driver does not pay per kWh, but for the time of using the Charge Point.
 
-- 2.00 euro per hour charging (not per kWh) (excluding VAT)
-- 10% VAT
-- Billed per 1 minutes (60 seconds)
+* Charging Time
+[disc]
+** 2.00 euro per hour (excl. VAT)
+** 10% VAT
+** Billed per 1 min (60 seconds)
 
-As this is tariff is only has a `TIME` price_component, the driver will not be billed for time not charging: `PARKING_TIME`
+As this is tariff only has a `TIME` price_component, the driver will not be billed for time they are not charging: `PARKING_TIME`
+
+For a charging session of 2.5 hours,
+this tariff will result in costs of 5.00 euro (excl. VAT) or 5.50 euro (incl. VAT).
 
 [source,json]
 ----
@@ -417,18 +444,23 @@ include::examples/tariff_1_simple_2hour.json[]
 ====== Simple Tariff example 3 euro per hour, 5 euro per hour parking
 
 Example of a tariff where the driver pays for the time of using the Charge Point, but pays more when the car is no longer charging,
-to discourage the EV driver of leaving his EV connected when it is full.
+to discourage the EV driver of leaving his EV connected when it is already full.
 
-* Charging time
+* Charging Time
 [disc]
-** 3.00 euro per hour charging (not per kWh) (excluding VAT)
+** 3.00 euro per hour (excl. VAT)
 ** 10% VAT
-** Billed per 1 minutes (60 seconds)
+** Billed per 1 min (60 seconds)
 * Parking
 [disc]
-** 5.00 euro per hour (excluding VAT)
+** 5.00 euro per hour (excl. VAT)
 ** 20% VAT
 ** Billed per 5 min (300 seconds)
+
+For a charging session of 2.5 hours where the vehicle is parked for 42 more minutes after charging ended,
+this tariff will result in costs of 11.25 euro (excl. VAT) or 12.75 euro (incl. VAT).
+Because the parking time is billed per 5 minutes, the driver has to pay for 45 minutes of parking even though
+they left 42 minutes after their vehicle stopped charging.
 
 [source,json]
 ----
@@ -439,13 +471,18 @@ include::examples/tariff_13_simple_3hour_5parking.json[]
 [[mod_tariffs_simple_tariff_example_with_alternative_multi_language_text]]
 ====== Ad-Hoc simple Tariff example with multiple languages
 
-For ad-hoc charging (paying for charging without a contract, the tariff `elements` are less needed.
-The eMSP is not involved when a driver uses ad-hoc payment at the Charge Point, so no CDR is send to an EMSP.
+For ad-hoc charging (paying for charging without a contract), the tariff `elements` are less needed.
+The eMSP is not involved when a driver uses ad-hoc payment at the Charge Point, so no CDR is send to an eMSP.
 Having a good human readable text is much more useful.
 
-- 2 euro per hour charging (not per kWh) (including VAT)
-- 5.2% VAT
-- Billed per 5 minutes (300 seconds)
+* Charging Time
+[disc]
+** 1.9 euro per hour (excl. VAT)
+** 5.2% VAT
+** Billed per 5 minutes (300 seconds)
+
+For a charging session of 2.5 hours,
+this tariff will result in costs of 4.75 euro (excl. VAT) or 5.00 euro (incl. VAT).
 
 [source,json]
 ----
@@ -456,10 +493,10 @@ include::examples/tariff_2_alt_text.json[]
 [[mod_tariffs_adhoc_tariff_example_not_possible_with_ocpi]]
 ====== Ad-Hoc Tariff example not possible with OCPI
 
-For this example, credit card start tariff is 0.50 euro, but when using a debit card it is only 0.25 euro.
+For this example, the credit card start tariff is 0.50 euro, but when using a debit card it is only 0.25 euro.
 
 Such a tariff cannot be modeled with OCPI. +
-But by modeling it as 0.50 euro start tariff, and giving using a debit card a discount in the final CDR of 0.25 euro, nobody is likely to complain.
+But by modeling it as 0.50 euro start tariff where debit card users are given a discount in the final CDR of 0.25 euro, nobody is likely to complain.
 The `tariff_alt_text` explains this clearly.
 
 [source,json]
@@ -473,15 +510,24 @@ include::examples/tariff_11_not_possible_alt_text.json[]
 
 This examples shows the use of `tariff_alt_url`.
 
-This examples shows a `PROFILE_CHEAP` tariff. This is a smart-charging tariff.
-Were a driver selects to charge as cheaply as possible.
+This examples shows a `PROFILE_CHEAP` tariff, which is a smart charging tariff.
+Drivers are able to select this tariff by setting the `profile_type` in their
+<<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preferences>> to `CHEAP`.
 In such case, the price might not be fixed, but depend on the real-time energy prices.
-To explain this to the driver, a short text inside `tariff_alt_text` might not be the best solution, maybe you want to show a graph.
-In such a case, an URL can be given that links to a better explanation of the tariff.
+To explain this to the driver, a short text inside `tariff_alt_text` might not be the best solution.
+Showing a graph could be better.
+It is also possible to provide an URL to a site that explains the tariff better and in more detail.
 
-- 0.25 euro per kWh (excluding VAT)
-- 10% VAT
-- Billed per 0.1 kWh (100 Wh)
+* Energy
+[disc]
+** 0.25 euro per kWh (excl. VAT)
+** 10% VAT
+** Billed per 0.1 kWh (100 Wh)
+
+For a charging session where 20.45 kWh are charged,
+this tariff will result in costs of 5.50 euro (excl. VAT) or 6.05 euro (incl. VAT).
+Because the energy is billed per 0.1 kWh, the driver has to pay for 20.5 kWh even though
+they only charged 20.45 kWh.
 
 [source,json]
 ----
@@ -492,21 +538,47 @@ include::examples/tariff_3_alt_url.json[]
 [[mod_tariffs_complex_tariff_example]]
 ====== Complex Tariff example
 
-- 2.50 euro start tariff
-- 1.00 euro per hour charging tariff for less than 32A (paid per 15 minutes)
-- 2.00 euro per hour charging tariff for more than 32A on weekdays (paid per 10 minutes)
-- 1.25 euro per hour charging tariff for more than 32A during the weekend (paid per 10 minutes)
+* Start or transaction fee
+[disc]
+** 2.50 euro (excl. VAT)
+** 15% VAT
+* Charging Time
+[disc]
+** When charging with less than 32A
+[disc]
+*** 1.00 euro per hour (excl. VAT)
+*** 20% VAT
+*** Billed per 15 min (900 seconds)
+** When charging with more than 32A on weekdays
+[disc]
+*** 2.00 euro per hour (excl. VAT)
+*** 20% VAT
+*** Billed per 10 min (600 seconds)
+** When charging with more than 32A on weekends
+[disc]
+*** 1.25 euro per hour (excl. VAT)
+*** 20% VAT
+*** Billed per 10 min (600 seconds)
+* Parking
+[disc]
+** On weekdays between 09:00 and 18:00
+[disc]
+*** 5 euro per hour (excl. VAT)
+*** 10% VAT
+*** Billed per 5 min (300 seconds)
+** On Saturday between 10:00 and 17:00
+[disc]
+*** 6 euro per hour (excl. VAT)
+*** 10% VAT
+*** Billed per 5 min (300 seconds)
 
-Parking costs:
+For a charging session on a Monday morning starting at 09:30 which takes 2.5 hours,
+where the driver uses 16A of power and is parking for additional 45 minutes afterwards,
+this tariff will result in costs of 8.75 euro (excl. VAT) or 10 euro (incl. VAT).
 
-- Weekdays: between 09:00 and 18:00 : 5 euro (paid per 5 minutes)
-- Saturday: between 10:00 and 17:00 : 6 euro (paid per 5 minutes)
-
-VAT:
-
-- 15% on start tariff
-- 20% on charging per hour
-- 10% on parking
+For a charging session on a Saturday afternoon starting at 13:30 which takes 2 hours,
+where the driver uses 43A of power and is parking for additional 75 minutes afterwards,
+this tariff will result in costs of 12.50 euro (excl. VAT) or 14,13 euro (incl. VAT).
 
 [source,json]
 ----
@@ -516,7 +588,9 @@ include::examples/tariff_4_complex.json[]
 
 [[mod_tariffs_free_of_charge_tariff_example]]
 ====== Free of Charge Tariff example
-In this example no VAT (that might not always be the case)
+In this example no VAT is given because it is not necessary (as the `price` is `0.00`).
+This might not always be the case though and it is of course permitted to add a VAT,
+even if the `price` is set to zero.
 
 [source,json]
 ----
@@ -527,14 +601,37 @@ include::examples/tariff_5_free_of_charge.json[]
 [[mod_tariffs_first_hour_free_energy]]
 ====== First hour free energy example
 
+In this example, we have the following scenario:
+
 * The first hour of parking time is free.
-* From the second to the fourth hour is 2.00 euro per hour
-* From the fourth on 3.00 euro per hour
+* From the second to the fourth hour, parking costs 2.00 euro per hour
+* From the fourth hour on, parking costs 3.00 euro per hour.
+* The first kWh of energy is free, every additional kWh costs 0.20 euro.
 
-Something similar applies to the kWh consumed.
+Translated into our tariff schema, the pricing model looks like this:
 
-* The first kWhs is free,
-* 0.20 euro per kWh for the rest.
+* Energy
+[disc]
+** First kWh: free
+** Any additional energy
+[disc]
+*** 0.20 euro per kWh (excl. VAT)
+*** Billed per 1 Wh
+* Parking
+[disc]
+** First hour of parking: free
+** Second to fourth hours of parking
+[disc]
+*** 2.00 euro per hour (excl. VAT)
+*** Billed per 1 min (60 seconds)
+** Any parking after four hours
+[disc]
+*** 3.00 euro per hour (excl. VAT)
+*** Billed per 1 min (60 seconds)
+
+For a charging session where the driver charges 20 kWh and where the vehicle is parked for 2.75 more hours after charging ended,
+this tariff will result in costs of 7.30 euro (excl. VAT).
+As no VAT information is given, it is not possible to calculate total costs including VAT.
 
 [source,json]
 ----
@@ -547,18 +644,21 @@ include::examples/tariff_7_first_hour_kwh_free.json[]
 
 * Reservation
 [disc]
-** 5.00 euro per hour (excluding VAT)
+** 5.00 euro per hour (excl. VAT)
 ** 20% VAT
-** Billed per 1 minute (60 seconds)
+** Billed per 1 min (60 seconds)
 * Start or transaction fee
 [disc]
-** 0.50 euro (excluding VAT)
+** 0.50 euro (excl. VAT)
 ** 20% VAT
 * Energy
 [disc]
-** 0.25 euro per kWh (excluding VAT)
+** 0.25 euro per kWh (excl. VAT)
 ** 10% VAT
 ** Billed per 1 Wh
+
+For a charging session that was started 15 minutes after the reservation time, where the driver charges 20 kWh,
+this tariff will result in costs of 6.75 euro (excl. VAT) or 7.60 euro (incl. VAT).
 
 [source,json]
 ----
@@ -571,19 +671,24 @@ include::examples/tariff_15_reservation_5_euro_per_hour.json[]
 
 * Reservation
 [disc]
-** 2.00 euro reservation fee (excluding VAT)
-** 5.00 euro per hour (excluding VAT)
+** 2.00 euro reservation fee (excl. VAT)
+** 5.00 euro per hour (excl. VAT)
 ** 20% VAT
-** Billed per 5 minutes (300 seconds)
+** Billed per 5 min (300 seconds)
 * Start or transaction fee
 [disc]
-** 0.50 euro (excluding VAT)
+** 0.50 euro (excl. VAT)
 ** 20% VAT
 * Energy
 [disc]
-** 0.25 euro per kWh (excluding VAT)
+** 0.25 euro per kWh (excl. VAT)
 ** 10% VAT
 ** Billed per 1 Wh
+
+For a charging session that was started 13 minutes after the reservation time, where the driver charges 20 kWh,
+this tariff will result in costs of 8.75 euro (excl. VAT) or 10.00 euro (incl. VAT).
+Because the reservation fee is billed per 5 minutes, the driver has to pay for 15 minutes of reservation even though
+they started the charging session 13 minutes after the reservation time.
 
 [source,json]
 ----
@@ -596,19 +701,34 @@ include::examples/tariff_16_reservation_2_euro_fee_5_euro_per_hour.json[]
 
 * Reservation
 [disc]
-** 4.00 euro reservation expire fee (excluding VAT) (when reservation not used, this fee is added to reservation cost)
-** 2.00 euro per hour (excluding VAT)
+** 4.00 euro reservation expiration fee (excl. VAT) (_billed when a reservation expires and is not followed by a charging session_)
+** 2.00 euro per hour (excl. VAT)
 ** 20% VAT
-** Billed per 10 minutes (600 seconds)
+** Billed per 10 min (600 seconds)
 * Start or transaction fee
 [disc]
-** 0.50 euro (excluding VAT)
+** 0.50 euro (excl. VAT)
 ** 20% VAT
 * Energy
 [disc]
-** 0.25 euro per kWh (excluding VAT)
+** 0.25 euro per kWh (excl. VAT)
 ** 10% VAT
 ** Billed per 1 Wh
+
+This example is very similar to <<mod_tariffs_tariff_example_15_reservation_5_euro_per_hour,Tariff example with reservation price>>
+with the difference that expired reservations cost something and that reservation time is billed per 10 minutes.
+Also, the price for reservation is different.
+
+For a charging session that was started 22 minutes after the reservation time, where the driver charges 20 kWh,
+this tariff will result in costs of 6.50 euro (excl. VAT) or 7.30 euro (incl. VAT).
+Because the reservation fee is billed per 10 minutes, the driver has to pay for 30 minutes of reservation even though
+they started the charging session 22 minutes after the reservation time.
+
+If the driver did not start a charging session and the reservation expired after the reserved time of 1 hour,
+the tariff would have resulted in costs of 6.00 euro (excl. VAT) or 7.20 euro (incl. VAT).
+In case a reservation is not used, the driver has to pay the full amount of reserved time
+as well as an additional expiration fee as compensation for not charging at all.
+
 
 [source,json]
 ----
@@ -621,31 +741,37 @@ include::examples/tariff_17_reservation_with_expire_fee.json[]
 
 * Reservation
 [disc]
-** 3.00 euro per hour (excluding VAT)
-** 6.00 euro per hour (excluding VAT) (When reservation expires, EV driver never starts to charge)
+** 3.00 euro per hour (excl. VAT)
+** 6.00 euro per hour (excl. VAT) (_billed when a reservation expires and is not followed by a charging session_)
 ** 20% VAT
-** Billed per 10 minutes (600 seconds)
+** Billed per 10 min (600 seconds)
 * Start or transaction fee
 [disc]
-** 0.50 euro (excluding VAT)
+** 0.50 euro (excl. VAT)
 ** 20% VAT
 * Energy
 [disc]
-** 0.25 euro per kWh (excluding VAT)
+** 0.25 euro per kWh (excl. VAT)
 ** 10% VAT
-** Billed per 100 Wh
+** Billed per 1 Wh
+
+This example is very similar to <<mod_tariffs_tariff_example_15_reservation_5_euro_per_hour,Tariff example with reservation price>>
+with the difference that expired reservations cost something and that reservation time is billed per 10 minutes.
+Also, the price for reservation is different.
+
+For a charging session that was started 22 minutes after the reservation time, where the driver charges 20 kWh,
+this tariff will result in costs of 7.00 euro (excl. VAT) or 7.90 euro (incl. VAT).
+Because the reservation fee is billed per 10 minutes, the driver has to pay for 30 minutes of reservation even though
+they started the charging session 22 minutes after the reservation time.
+
+If the driver did not start a charging session and the reservation expired after the reserved time of 1.5 hours,
+the tariff would have resulted in costs of 9.00 euro (excl. VAT) or 10.80 euro (incl. VAT).
+In case a reservation is not used, the driver has to pay the expiration fee as compensation for not charging at all.
 
 [source,json]
 ----
-include::examples/tariff_17_reservation_with_expire_fee.json[]
+include::examples/tariff_18_reservation_with_expire_time.json[]
 ----
-
-Example of cost:
-
-- EV driver reserves the EVSE for half an hour (30 minutes).
-- When the driver would start charging after 9 minutes, and charges 47.92 kWh: 0.50 + 0.50 + 12 = 13.00 euro (excluding VAT)
-- When the driver would start charging after 12 minutes, and charges 62.98 kWh: 1.00 + 0.50 + 15.75 = 17.25 euro (excluding VAT)
-- When the driver never start to charge before the reservation expires, cost: 3.00 euro (excluding VAT)
 
 
 [[mod_tariffs_data_types]]
@@ -674,73 +800,79 @@ Example of cost:
 |===
 |Property |Type |Card. |Description 
 
-|type |<<mod_tariffs_tariffdimensiontype_enum,TariffDimensionType>> |1 |Type of tariff dimension 
-|price |<<types.asciidoc#types_number_type,number>> |1 |price per unit (excluding VAT) for this tariff dimension 
-|vat |<<types.asciidoc#types_number_type,number>> |? |applicable VAT percentage for this tariff dimension. If omitted, no VAT is applicable, that is different from 0% VAT, which would be a value of 0.0 here.
-|step_size |int |1 |Minimum amount to be billed. This unit will be billed in this step_size blocks. For example: if type is time and step_size is 300, then time will be billed in blocks of 5 minutes, so if 6 minutes is used, 10 minutes (2 blocks of step_size) will be billed.
+|type |<<mod_tariffs_tariffdimensiontype_enum,TariffDimensionType>> |1 |Type of tariff dimension.
+|price |<<types.asciidoc#types_number_type,number>> |1 |Price per unit (excl. VAT) for this tariff dimension.
+|vat |<<types.asciidoc#types_number_type,number>> |? |Applicable VAT percentage for this tariff dimension. If omitted, no VAT is applicable. Not providing a VAT is different from 0% VAT, which would be a value of 0.0 here.
+|step_size |int |1 |Minimum amount to be billed. This unit will be billed in this `step_size` blocks. For example: if `type` is `TIME` and `step_size` has a value of `300`, then time will be billed in blocks of 5 minutes. If 6 minutes were used, 10 minutes (2 blocks of `step_size`) will be billed.
 |===
 
-NOTE: `step_size`: depends on the `type`, every `type` (except `FLAT`) defines a step_size multiplier, this is the size of every 'step' for that type in the gaven unit. +
+NOTE: `step_size`: depends on the `type` and every `type` (except `FLAT`) defines a `step_size` multiplier, which is the size of every _step_ for that `type` in the givgen unit. +
  +
-For example: `PARKING_TIME` has 'step_size multiplier: 1 second' That means that the `step_size` of a `PriceComponent` is multiplied by 1 second.
-Thus a `step_size = 300` means 300 seconds = 5 minutes, this means that when somebody has parked for 8 minutes he will be billed for 10, parked for 11 minutes then billed for 15. (steps of 5 minutes) +
+For example: `PARKING_TIME` has the `step_size` multiplier: _1 second_, which means that the `step_size` of a `PriceComponent` is multiplied by _1 second_.
+Thus a `step_size = 300` means `300 seconds` (`5 minutes`). This means that when someone parked for 8 minutes they will be billed for 10 minutes.
+The parking time will be simply rounded up to the next larger chunk of `step_size` (i.e. blocks of `300 seconds` in this example). +
  +
-Example with `ENERGY`: `Price`= 0.25, `step_size` = 1. +
-Then energy is billed per 1 Wh. If somebody charges his EV with 115.2 Wh, then he is billed for 116 Wh, price: 0.029. +
-When `step_size` = 25, then the same amount will be billed for 125 Wh, price: 0.031. +
-When `step_size` = 500, then the same amount will be billed for 500 Wh, price: 0.125.
+Another example: `ENERGY` has the `step_size` multiplied: _1 Wh_, which means that the `step_size` of a `PriceComponent` is multiplied by _1 Wh_.
+Thus a `step_size = 1` with a `price = 0.25` will result in a cost calculation that uses the charged Wh as precision. +
+If someone charges their EV with 115.2 Wh, then they are billed for 116 Wh, resulting in total cost of 0.029 euro. +
+When `step_size = 25`, then the same amount would be billed for 101 to 125 Wh: 0.031 euro. +
+When `step_size = 500`, then the same amount will be billed for 1 to 500 Wh: 0.125 euro.
 
-NOTE: `step_size` shall only be taken into account for the last <<mod_tariffs_tariffelement_class,`TariffElement`>>
+NOTE: `step_size` SHALL only be taken into account for the last <<mod_tariffs_tariffelement_class,`TariffElement`>>
 and when switching to another <<mod_tariffs_tariffelement_class,`TariffElement`>> for the <<mod_tariffs_pricecomponent_class,`PriceComponents`>>
-that are not in the new <<mod_tariffs_tariffelement_class,`TariffElement`>>.
-The same rule applies in case there is a switch between 2 tariffs
+that is not in the new <<mod_tariffs_tariffelement_class,`TariffElement`>>.
+The same rule applies in case there is a switch between 2 Tariffs
 (for example when a driver selects a different <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>> <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,`profile_type`>>).
 
 
-===== Examples tariff
-Example tariff for explaining `step_size` when switching from one <<mod_tariffs_tariffelement_class,`TariffElement`>> to another:
+===== Example Tariff
+Example Tariff to explain the `step_size` when switching from one <<mod_tariffs_tariffelement_class,`TariffElement`>> to another:
 
-- Charging cost 1.20 euro p/hour before 17:00, step_size: 30 minutes (1800 seconds)
-- Charging cost 2.40 euro p/hour after 17:00, step_size: 15 minutes (900 seconds)
-- Parking  cost 1.00 euro p/hour before 20:00, step_size: 15 minutes (900 seconds)
+- Charging fee of 1.20 euro per hour (excl. VAT) before 17:00 with a `step_size` of 30 minutes (1800 seconds)
+- Charging fee of 2.40 euro per hour (excl. VAT) after 17:00 with a `step_size` of 15 minutes (900 seconds)
+- Parking fee of 1.00 euro per hour (excl. VAT) before 20:00 with a `step_size` of 15 minutes (900 seconds)
 
 [source,json]
 ----
 include::examples/tariff_14_step_size.json[]
 ----
 
-===== Example switch to different price:
+====== Example: switching to different Tariff Element #1
 
-An EV driver plugs in at 16:55, charges for 10 minutes (TIME), stops charging but stays plugged in for 2 min (PARKING TIME), and then leaves. Total session time = 12min.
+An EV driver plugs in at 16:55 and charges for 10 minutes (`TIME`).
+They then stop charging but stay plugged in for 2 more minutes (`PARKING_TIME`).
+The total session time is therefore 12 minutes, resulting in the following costs:
 
-- 5 billable minutes charging time before 17:00: 1.20 euro p/hour = 0.10 euro
-- 10 billable minutes charging time after 17:00: 2.40 euro p/hour = 0.40 euro (10 minutes billed instead of 5: step_size is 15 minutes in the last tariff element, so total charging time is billed for 15 minutes)
-- 15 billable minutes parking time: 1 euro p/hour = 0.25 euro
-- 0.75 euro total for this session.
+- 5 billable minutes of charging time before 17:00, generating costs of 0.10 euro.
+- 10 billable minutes of charging time after 17:00, generating costs of 0.40 euro. As the Price Component of the last Tariff Element being used has a `step_size` of 15 minutes, we bill a total charging duration of 15 minutes. When considering the already billed 5 minutes of charging time before 17:00, we are left with 10 minutes to bill after 17:00.
+- 15 billable minutes of parking time, generating costs of 0.25 euro.
+- The total for this charging session is therefore *0.75 euro* (excl. VAT).
 
+====== Example: switching to different Tariff Element #2
 
-Other example: if the EV driver plugs in at 16h35, and charges for 35 minutes (TIME) :
+An EV driver plugs in at 16:35 and charges for 35 minutes (`TIME`).
+After that they immediately unplug, leaving with a total session time of 35 minutes and a bill over the following costs:
 
-- 25 billable minutes charging time before 17:00: 1.20 euro p/hour = 0.50 euro
-- 20 billable minutes charging time after 17:00: 2.40 euro p/hour = 0.80 euro (20 minutes billed instead of 10: step_size is 15 minutes in the last tariff element, so total charging time is billed for 45 minutes)
-- 45 billable minutes parking time: 1 euro p/hour = 0.75 euro
-- 2.05 euro total for this session.
+- 25 billable minutes of charging time before 17:00, generating costs of 0.50 euro.
+- 20 billable minutes of charging time after 17:00, generating costs of 0.80 euro. As the Price Component of the last Tariff Element being used has a `step_size` of 15 minutes, we bill a total charging duration of 45 minutes. When considering the already billed 25 minutes of charging time before 17:00, we are left with 20 minutes to bill after 17:00.
+- 45 billable minutes of parking time, generating costs of 0.75 euro.
+- The total for this charging session is therefore *2.05 euro* (excl. VAT).
 
-
-===== Example switching to free tariff element:
+====== Example: switching to Free-of-Charge Tariff Element
 
 When parking becomes free after 20:00, the new <<mod_tariffs_tariffelement_class,`TariffElement`>> after 20:00 will not contain a
-<<mod_tariffs_tariffdimensiontype_enum,`PARKING_TIME`>> <<mod_tariffs_pricecomponent_class,`PriceComponent`>>. So the last parking period that needs to be payed,
-before 20:00, will be billed per step_size of the <<mod_tariffs_tariffdimensiontype_enum,`PARKING_TIME`>> <<mod_tariffs_pricecomponent_class,`PriceComponent`>> before 20:00.
+<<mod_tariffs_tariffdimensiontype_enum,`PARKING_TIME`>> <<mod_tariffs_pricecomponent_class,`PriceComponent`>>.
+So the last parking period that needs to be payed, which is before 20:00, will be billed according to the `step_size`
+of the <<mod_tariffs_tariffdimensiontype_enum,`PARKING_TIME`>> <<mod_tariffs_pricecomponent_class,`PriceComponent`>> before 20:00.
 
-Example of this:
+An EV driver plugs in at 19:55 and charges for 10 minutes (`TIME`).
+They then stop charging but stay plugged in for 2 more minutes (`PARKING_TIME`).
+The total session time is therefore 12 minutes, resulting in the following costs:
 
-An EV driver plugs in at 19:55, charges for 10 min (TIME), stops charging but stays plugged in for 2 min (PARKING TIME), and then leaves. Total session time = 12min.
-
-- 5 billable minutes charging time before 20:00: 2.40 euro p/hour = 0.20 euro
-- 10 billable minutes charging time after 20.00: 2.40 euro p/hour = 0.40 euro (10 minutes billed instead of 5: step_size is 15 minutes in the last tariff element, so total charging time is billed for 15 minutes)
-- 15 billable minutes parking time: 1 euro p/hour = 0.25 euro (15 minutes billed instead of 5: step_size of the last PARKING_TIME is 900: 15 minutes)
-- 0.85 euro total for this session.
+- 5 billable minutes of charging time before 20:00, generating costs of 0.20 euro.
+- 10 billable minutes of charging time after 20:00, generating costs of 0.40 euro. As the Price Component of the last Tariff Element being used has a `step_size` of 15 minutes, we bill a total charging duration of 15 minutes. When considering the already billed 5 minutes of charging time before 20:00, we are left with 10 minutes to bill after 20:00.
+- 15 billable minutes of parking time, generating costs of 0.25 euro. As the last Price Component with `type = PARKING_TIME` has a `step_size` of 15 minutes, we do round up to the `step_size` of 15 minutes even though only 5 minutes of parking that happened before 20:00.
+- The total for this charging session is therefore *0.85 euro* (excl. VAT).
 
 
 [[mod_tariffs_reservation_restriction_type]]
@@ -749,12 +881,13 @@ An EV driver plugs in at 19:55, charges for 10 min (TIME), stops charging but st
 [cols="3,10",options="header"]
 |===
 |Value |Description
-|RESERVATION |This TariffElement is for the cost associated with a reservation.
-|RESERVATION_EXPIRES | This TariffElement is only for cost associated with a reservation that expires, driver does not start a charging session before <<mod_commands.asciidoc#mod_commands_reservenow_object,expiry_date>>.
+|RESERVATION |Used in TariffElements to describe costs for a reservation.
+|RESERVATION_EXPIRES |Used in TariffElements to describe costs for a reservation that expires (i.e. driver does not start a charging session before <<mod_commands.asciidoc#mod_commands_reservenow_object,expiry_date>> of the reservation).
 |===
 
-NOTE: When a Tariff has both a `RESERVATION` and a `RESERVATION_EXPIRES` TariffElement, with both a  <<mod_tariffs_tariffdimensiontype_enum,TIME>> PriceComponent,
-the time based cost of an expired reservation duration will be the price in the `RESERVATION_EXPIRES` TariffElement.
+NOTE: When a Tariff has both, `RESERVATION` and `RESERVATION_EXPIRES` TariffElements,
+where both TariffElements have a <<mod_tariffs_tariffdimensiontype_enum,TIME>> PriceComponent,
+then the time based cost of an expired reservation will be calculated based on the `RESERVATION_EXPIRES` TariffElement.
 
 [[mod_tariffs_tariffelement_class]]
 ==== TariffElement _class_
@@ -763,8 +896,8 @@ the time based cost of an expired reservation duration will be the price in the 
 |===
 |Property |Type |Card. |Description 
 
-|price_components |<<mod_tariffs_pricecomponent_class,PriceComponent>> |+ |List of price components that make up the pricing of this tariff 
-|restrictions |<<mod_tariffs_tariffrestrictions_class,TariffRestrictions>> |? |Tariff restrictions object 
+|price_components |<<mod_tariffs_pricecomponent_class,PriceComponent>> |+ |List of price components that describe the pricing of a tariff.
+|restrictions |<<mod_tariffs_tariffrestrictions_class,TariffRestrictions>> |? |Restrictions that describe the applicability of a tariff.
 |===
 
 [[mod_tariffs_tariffdimensiontype_enum]]
@@ -774,111 +907,111 @@ the time based cost of an expired reservation duration will be the price in the 
 |===
 |Value |Description 
 
-|ENERGY |defined in kWh, step_size multiplier: 1 Wh 
-|FLAT |flat fee, no unit 
-|PARKING_TIME |time not charging: defined in hours, step_size multiplier: 1 second 
-|TIME |time charging: defined in hours, step_size multiplier: 1 second +
-Can also be used in combination with <<mod_tariffs_tariffrestrictions_class,reservation>> for the the price of the reservation time.
+|ENERGY |Defined in kWh, `step_size` multiplier: 1 Wh 
+|FLAT |Flat fee without unit for `step_size`
+|PARKING_TIME |Time not charging: defined in hours, `step_size` multiplier: 1 second 
+|TIME |Time charging: defined in hours, `step_size` multiplier: 1 second +
+Can also be used in combination with a <<mod_tariffs_tariffrestrictions_class,RESERVATION>> restriction to describe the price of the reservation time.
 |===
 
 
 [[mod_tariffs_tariffrestrictions_class]]
 ==== TariffRestrictions _class_
 
-These restrictions are not for the entire Charging Session, but the TariffRestrictions make a TariffElement become active or inactive during a Charging Session.
+These restrictions are not for the entire Charging Session. They only describe if and when a TariffElement becomes active or inactive during a Charging Session.
 
 [cols="3,2,1,10",options="header"]
 |===
 |Property |Type |Card. |Description 
 
-|start_time |<<types.asciidoc#types_string_type,string>>(5) |? |Start time of day, for example 13:30, valid from this time of the day. Must be in 24h format with leading zeros. Hour/Minute separator: ":" Regex: [0-2][0-9]:[0-5][0-9] 
-|end_time |<<types.asciidoc#types_string_type,string>>(5) |? |End time of day, for example 19:45, valid until this time of the day. Same syntax as start_time 
-|start_date |<<types.asciidoc#types_string_type,string>>(10) |? |Start date, for example: 2015-12-24, valid from this day 
-|end_date |<<types.asciidoc#types_string_type,string>>(10) |? |End date, for example: 2015-12-27, valid until this day (excluding this day) 
-|min_kwh |<<types.asciidoc#types_number_type,number>> |? |Minimum used energy in kWh, for example 20, valid from this amount of energy is used 
-|max_kwh |<<types.asciidoc#types_number_type,number>> |? |Maximum used energy in kWh, for example 50, valid until this amount of energy is used 
-|min_current |<<types.asciidoc#types_number_type,number>> |? |Sum of the minimum current in A over all phases, for example 5. When the Charging Session is charging more then this amount of current,
-                                                            this TariffElement is/becomes active. Is the charging current is lower, this TariffElement is not valid.
-                                                            This is NOT the minimum current over the entire Charging Session.
-                                                            This restriction can make a TariffElement become active when the charging current is above this value,
-                                                            but the TariffElement is no longer active when charging drops below this current.
-|max_current |<<types.asciidoc#types_number_type,number>> |? |Sum of the maximum current in A over all phases, for example 20. When the Charging Session is charging less then this amount of current,
-                                                         this TariffElement becomes/is active. Is the charging current is higher, this TariffElement is not valid.
-                                                         This is NOT the maximum current over the entire Charging Session.
-                                                         This restriction can make a TariffElement become active when the charging current is below this value,
-                                                         but the TariffElement is no longer active when charging comes above this current.
-|min_power |<<types.asciidoc#types_number_type,number>> |? |Minimum power in kW, for example 5. When the Charging Session is consuming more then this amount of power,
-                                                            this TariffElement is/becomes active. Is the charging power is lower, this TariffElement is not valid.
-                                                            This is NOT the minimum power over the entire Charging Session.
-                                                            This restriction can make a TariffElement become active when the charging power is above this value,
-                                                            but the TariffElement is no longer active when charging drops below this power.
-|max_power |<<types.asciidoc#types_number_type,number>> |? |Maximum power in kW, for example 20. When the Charging Session is consuming less then this amount of power,
-                                                         this TariffElement becomes/is active. Is the charging power is higher, this TariffElement is not valid.
-                                                         This is NOT the maximum power over the entire Charging Session.
-                                                         This restriction can make a TariffElement become active when the charging power is below this value,
-                                                         but the TariffElement is no longer active when charging comes above this power.
-|min_duration |int |? |Minimum duration in seconds the Charging Session is ongoing. When the duration of the ongoing Charging Session is longer then this value,
-                      this TariffElement is active, before that moment this TariffElement is not yet active. Duration in seconds.
-|max_duration |int |? |Maximum duration in seconds the Charging Session is ongoing. When the duration of the ongoing Charging Session is shorted then this value,
-                      this TariffElement is active, after that moment this TariffElement is no longer active. Duration in seconds.
+|start_time |<<types.asciidoc#types_string_type,string>>(5) |? |Start time of day, for example 13:30, valid from this time of the day. Must be in 24h format with leading zeros. Hour/Minute separator: ":" Regex: `[0-2][0-9]:[0-5][0-9]`
+|end_time |<<types.asciidoc#types_string_type,string>>(5) |? |End time of day, for example 19:45, valid until this time of the day. Same syntax as `start_time`.
+|start_date |<<types.asciidoc#types_string_type,string>>(10) |? |Start date, for example: 2015-12-24, valid from this day. Regex: `([12][0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])`
+|end_date |<<types.asciidoc#types_string_type,string>>(10) |? |End date, for example: 2015-12-27, valid until this day (exclusive). Same syntax as `start_date`.
+|min_kwh |<<types.asciidoc#types_number_type,number>> |? |Minimum consumed energy in kWh, for example 20, valid from this amount of energy being used.
+|max_kwh |<<types.asciidoc#types_number_type,number>> |? |Maximum consumed energy in kWh, for example 50, valid until this amount of energy being used.
+|min_current |<<types.asciidoc#types_number_type,number>> |? |Sum of the minimum current in A over all phases, for example 5.
+      When the EV is charging with more than the defined amount of current, this TariffElement is/becomes active.
+      If the charging current is or becomes lower, this TariffElement is not or no longer valid and becomes inactive.
+      This describes NOT the minimum current over the entire Charging Session.
+      This restriction can make a TariffElement become active when the charging current is above the defined value,
+      but the TariffElement MUST no longer be active when the charging current drops below the defined value.
+|max_current |<<types.asciidoc#types_number_type,number>> |? |Sum of the maximum current in A over all phases, for example 20.
+      When the EV is charging with less than the defined amount of current, this TariffElement becomes/is active.
+      If the charging current is or becomes higher, this TariffElement is not or no longer valid and becomes inactive.
+      This describes NOT the maximum current over the entire Charging Session.
+      This restriction can make a TariffElement become active when the charging current is below this value,
+      but the TariffElement MUST no longer be active when the charging current raises above the defined value.
+|min_power |<<types.asciidoc#types_number_type,number>> |? |Minimum power in kW, for example 5.
+      When the EV is charging with more than the defined amount of power, this TariffElement is/becomes active.
+      If the charging power is or becomes lower, this TariffElement is not or no longer valid and becomes inactive.
+      This describes NOT the minimum power over the entire Charging Session.
+      This restriction can make a TariffElement become active when the charging power is above this value,
+      but the TariffElement MUST no longer be active when the charging power drops below the defined value.
+|max_power |<<types.asciidoc#types_number_type,number>> |? |Maximum power in kW, for example 20.
+      When the EV is charging with less than the defined amount of power, this TariffElement becomes/is active.
+      If the charging power is or becomes higher, this TariffElement is not or no longer valid and becomes inactive.
+      This describes NOT the maximum power over the entire Charging Session.
+      This restriction can make a TariffElement become active when the charging power is below this value,
+      but the TariffElement MUST no longer be active when the charging power raises above the defined value.
+|min_duration |int |? |Minimum duration in seconds the Charging Session MUST last (inclusive).
+      When the duration of a Charging Session is longer than the defined value, this TariffElement is or becomes active.
+      Before that moment, this TariffElement is not yet active.
+|max_duration |int |? |Maximum duration in seconds the Charging Session MUST last (exclusive).
+      When the duration of a Charging Session is shorter than the defined value, this TariffElement is or becomes active.
+      After that moment, this TariffElement is no longer active.
 |day_of_week |<<mod_tariffs_dayofweek_enum,DayOfWeek>> |* |Which day(s) of the week this TariffElement is active.
-|reservation |<<mod_tariffs_reservation_restriction_type,ReservationRestrictionType>> |? |When this field is present, this tariffElement is for a reservation.
-A reservation starts when the reservation is made, and ends when the drivers start charging on the reserved EVSE/Location, or when the reservation expires.
-A reservation can only have: <<mod_tariffs_tariffdimensiontype_enum,FLAT>> and <<mod_tariffs_tariffdimensiontype_enum,TIME>> TariffDimensions, where TIME is for the duration of the reservation.
+|reservation |<<mod_tariffs_reservation_restriction_type,ReservationRestrictionType>> |? |When this field is present, the TariffElement describes reservation costs.
+A reservation starts when the reservation is made, and ends when the drivers starts charging on the reserved EVSE/Location, or when the reservation expires.
+A reservation can only have: <<mod_tariffs_tariffdimensiontype_enum,FLAT>> and <<mod_tariffs_tariffdimensiontype_enum,TIME>> TariffDimensions, where `TIME` is for the duration of the reservation.
 |===
 
 
-===== Examples tariffRestriction max_power
+===== Example: Tariff with max_power Tariff Restrictions
 
-- Charging slower then 16 kW cost 1.00 euro p/hour (ex VAT)
-- Charging between 16 kW and 32 kW cost 1.50 euro p/hour (ex VAT)
-- Charging faster then 32 kW cost 2.00 euro p/hour (ex VAT) (no restriction: fallback tariff)
+Example Tariff to explain the `max_power` Tariff Restriction:
+
+- Charging fee of 1.00 euro per kWh (excl. VAT) when charging with a power of less than 16 kW.
+- Charging fee of 1.50 euro per kWh (excl. VAT) when charging with a power between 16 and 32 kW.
+- Charging fee of 2.00 euro per kWh (excl. VAT) when charging with a power above 32 kW (implemented as fallback tariff without Restriction).
+
+For a charging session where the EV charges the first kWh with a power of 6 kW,
+increases the power to 48 kW for the next 40 kWh and reduces it again to 4 kW after that for another 0.5 kWh
+(probably due to physical limitations, i.e. temperature of the battery),
+this tariff will result in costs of 20.30 euro (excl. VAT). The costs are composed of the following components:
+
+- 1 kWh at 6 kW: 0.20 euro
+- 40 kWh at 48 kW: 20.00 euro
+- 0.5 kWh at 4 kW: 0.10 euro
 
 [source,json]
 ----
 include::examples/tariffrestriction_example_max_power.json[]
 ----
 
-Using this example: when a charging session starts with the first kWh at 6 kW,
-then goes to 48 kWh charging and charges 40 kWh, then the EV is almost full and charging slows down to 4 kW,
-0.5 kWh is charged at this slower speed before the EV is unplugged.
 
-The cost will be:
-
-- 1 kWh at 6 kW: 0.20 euro
-- 40 kWh at 48 kW: 20.00 euro
-- 0.5 kWh at: 4 kW: 0.10 euro
-
-Total: 20.30 euro.
-
-
-===== Examples tariffRestriction max_duration
+===== Example: Tariff with max_duration Tariff Restrictions
 
 A supermarket wants to allow their customer to charge for free.
-
 As most customers will be out of the store in 20 minutes, they allow free charging for 30 minutes.
-If a customer charger longer they will charge him the normal price per kWh.
-But they also don't want customers to use their Charge Points and thus parking space for too long.
-So to discourage long use, charging becomes much more expensive after 1 hour:
+If a customer charges longer than that, they will charge them the normal price per kWh.
+But as they want to discourage long usage of their Charge Points, charging becomes much more expensive after 1 hour:
 
-- First 30 minutes charging is free.
-- After that: 0.25 euro per kWh (ex VAT)
-- After 60 minutes: 0.40 euro per kWh (ex VAT)
+- First 30 minutes of charging is free.
+- Charging fee of 0.25 euro per kWh (excl. VAT) after 30 minutes.
+- Charging fee of 0.40 euro per kWh (excl. VAT) after 60 minutes.
+
+For a charging session with a duration of 40 minutes where 5 kWh are charged during the first 30 minutes
+and another 1.2 kWh in the remaining 10 minutes of the session,
+this tariff will result in costs of 0.30 euro (excl. VAT). The costs are composed of the following components:
+
+- 5 kWh for free: 0.00 euro
+- 1.2 kWh at 0.25/kWh: 0.30 euro
 
 [source,json]
 ----
 include::examples/tariffrestriction_example_max_duration.json[]
 ----
-
-Using this example: an EV charges for 40 minutes.
-The first half hour: 5 kWh is charged, then the last 10 minutes: 1.2 kWh is charged
-
-The cost will be:
-
-- 5 kWh for free: 0.00 euro
-- 1.2 kWh at 0.25/kWh: 0.30 euro
-
-Total: 0.30 euro.
 
 
 [[mod_tariffs_tariff_type]]
@@ -888,9 +1021,9 @@ Total: 0.30 euro.
 |===
 |Value |Description
 
-|AD_HOC_PAYMENT |This tariff is valid when ad hoc payment is used at the Charge Point, for example Debit or Credit card payment terminal. Instead of an RFID token or APP.
-|PROFILE_CHEAP |This tariff is valid when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,CHEAP>> is set on the session.
-|PROFILE_FAST |This tariff is valid when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,FAST>> is set on the session.
-|PROFILE_GREEN |This tariff is valid when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,GREEN>> is set on the session.
-|REGULAR |This is the tariff when using an RFID, without any Charging Preference, or when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,REGULAR>> is set on the session.
+|AD_HOC_PAYMENT |Used to describe that a Tariff is valid when ad-hoc payment is used at the Charge Point (for example: Debit or Credit card payment terminal).
+|PROFILE_CHEAP |Used to describe that a Tariff is valid when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,CHEAP>> is set for the session.
+|PROFILE_FAST |Used to describe that a Tariff is valid when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,FAST>> is set for the session.
+|PROFILE_GREEN |Used to describe that a Tariff is valid when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,GREEN>> is set for the session.
+|REGULAR |Used to describe that a Tariff is valid when using an RFID, without any Charging Preference, or when <<mod_sessions.asciidoc#mod_sessions_set_charging_preferences,Charging Preference>>: <<mod_sessions.asciidoc#mod_sessions_profile_type_enum,REGULAR>> is set for the session.
 |===

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -939,7 +939,7 @@ These restrictions are not for the entire Charging Session. They only describe i
 
 |start_time |<<types.asciidoc#types_string_type,string>>(5) |? |Start time of day, for example 13:30, valid from this time of the day. Must be in 24h format with leading zeros. Hour/Minute separator: ":" Regex: `[0-2][0-9]:[0-5][0-9]`
 |end_time |<<types.asciidoc#types_string_type,string>>(5) |? |End time of day, for example 19:45, valid until this time of the day. Same syntax as `start_time`.
-|start_date |<<types.asciidoc#types_string_type,string>>(10) |? |Start date, for example: 2015-12-24, valid from this day. Regex: `([12][0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])`
+|start_date |<<types.asciidoc#types_string_type,string>>(10) |? |Start date, for example: 2015-12-24, valid from this day. Regex: `([12][0-9]{3})-(0[1-9]\|1[0-2])-(0[1-9]\|[12][0-9]\|3[01])`
 |end_date |<<types.asciidoc#types_string_type,string>>(10) |? |End date, for example: 2015-12-27, valid until this day (exclusive). Same syntax as `start_date`.
 |min_kwh |<<types.asciidoc#types_number_type,number>> |? |Minimum consumed energy in kWh, for example 20, valid from this amount of energy being used.
 |max_kwh |<<types.asciidoc#types_number_type,number>> |? |Maximum consumed energy in kWh, for example 50, valid until this amount of energy being used.

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -517,7 +517,8 @@ Drivers are able to select this tariff by setting the `profile_type` in their
 In such case, the price might not be fixed, but depend on the real-time energy prices.
 To explain this to the driver, a short text inside `tariff_alt_text` might not be the best solution.
 Showing a graph could be better.
-It is also possible to provide an URL to a site that explains the tariff better and in more detail.
+Therefore it is also possible to provide an URL in `tariff_alt_url` to a site that explains
+the tariff better and in more detail.
 
 * Energy
 [disc]
@@ -526,9 +527,15 @@ It is also possible to provide an URL to a site that explains the tariff better 
 ** Billed per 0.1 kWh (100 Wh)
 
 For a charging session where 20.45 kWh are charged,
-this tariff will result in costs of 5.50 euro (excl. VAT) or 6.05 euro (incl. VAT).
+this tariff will result in costs of 5.50 euro (excl. VAT) or 6.05 euro (incl. VAT)
+if the announced prices were billed.
 Because the energy is billed per 0.1 kWh, the driver has to pay for 20.5 kWh even though
 they only charged 20.45 kWh.
+
+The twist here is that this tariff makes use of `tariff_alt_url` which links to a page
+with real-time energy prices of the operator, where is shown that the actual price per kWh is different.
+With an assumed current energy price of 0.22 euro per kWh (excl. VAT), which is shown or explained on
+the page linked by `tariff_alt_url`, the resulting costs will be 4.51 euro (excl. VAT) or 4.96 euro (incl. VAT).
 
 [source,json]
 ----

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -583,12 +583,9 @@ include::examples/tariff_3_alt_url.json[]
 *** 10% VAT
 *** Billed per 5 min (300 seconds)
 
-For a charging session on a Monday morning starting at 09:30 which takes 2.5 hours,
-where the driver uses a maximum of 16A of power and is parking for additional 45 minutes afterwards,
 For a charging session on a Monday morning starting at 09:30 which takes 2.45 hours,
 where the driver uses a maximum of 16A of power and is parking for additional 42 minutes afterwards,
 this tariff will result in costs of 8.75 euro (excl. VAT) or 10 euro (incl. VAT)
-for a total session time of 150 minutes (charging) + 45 minutes (parking).
 for a total session time of 147 minutes (charging) + 42 minutes (parking).
 Because charging is billed per 15 minutes, the driver has to pay for 150 minutes.
 Similarly, the driver has to pay for 45 minutes of parking as its billed per 5 minutes.

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -295,6 +295,9 @@ the driver might get billed something they didn't agree to when starting the ses
 [[mod_tariffs_examples]]
 ===== Examples
 
+In the following section, a few different pricing strategies will be explained with some Tariff examples.
+For simplicity, we will use euro as currency in all of the examples if not mentioned otherwise.
+
 [[mod_tariffs_simple_tariff_example_0_25_euro_per_kwh]]
 ====== Simple Tariff example 0.25 euro per kWh
 

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -581,12 +581,12 @@ include::examples/tariff_3_alt_url.json[]
 *** Billed per 5 min (300 seconds)
 
 For a charging session on a Monday morning starting at 09:30 which takes 2.5 hours,
-where the driver uses 16A of power and is parking for additional 45 minutes afterwards,
+where the driver uses a maximum of 16A of power and is parking for additional 45 minutes afterwards,
 this tariff will result in costs of 8.75 euro (excl. VAT) or 10 euro (incl. VAT)
 for a total session time of 150 minutes (charging) + 45 minutes (parking).
 
 For a charging session on a Saturday afternoon starting at 13:30 which takes 2 hours,
-where the driver uses 43A of power and is parking for additional 75 minutes afterwards,
+where the driver uses a minimum of 43A of power and is parking for additional 75 minutes afterwards,
 this tariff will result in costs of 12.50 euro (excl. VAT) or 14,13 euro (incl. VAT)
 for a total session time of 120 minutes (charging) + 75 minutes (parking).
 

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -458,6 +458,7 @@ to discourage the EV driver of leaving his EV connected when it is already full.
 ** Billed per 5 min (300 seconds)
 
 For a charging session of 2.5 hours where the vehicle is parked for 42 more minutes after charging ended,
+resulting in a total session time of 150 minutes (charging) + 42 minutes (parking),
 this tariff will result in costs of 11.25 euro (excl. VAT) or 12.75 euro (incl. VAT).
 Because the parking time is billed per 5 minutes, the driver has to pay for 45 minutes of parking even though
 they left 42 minutes after their vehicle stopped charging.
@@ -574,11 +575,13 @@ include::examples/tariff_3_alt_url.json[]
 
 For a charging session on a Monday morning starting at 09:30 which takes 2.5 hours,
 where the driver uses 16A of power and is parking for additional 45 minutes afterwards,
-this tariff will result in costs of 8.75 euro (excl. VAT) or 10 euro (incl. VAT).
+this tariff will result in costs of 8.75 euro (excl. VAT) or 10 euro (incl. VAT)
+for a total session time of 150 minutes (charging) + 45 minutes (parking).
 
 For a charging session on a Saturday afternoon starting at 13:30 which takes 2 hours,
 where the driver uses 43A of power and is parking for additional 75 minutes afterwards,
-this tariff will result in costs of 12.50 euro (excl. VAT) or 14,13 euro (incl. VAT).
+this tariff will result in costs of 12.50 euro (excl. VAT) or 14,13 euro (incl. VAT)
+for a total session time of 120 minutes (charging) + 75 minutes (parking).
 
 [source,json]
 ----

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -65,17 +65,17 @@ Fetch information about all Tariffs.
 
 Endpoint structure definition:
 
-`{tariffs_endpoint_url}?[date_from={date_from}]&amp;[date_to={date_to}]&amp;[offset={offset}]&amp;[limit={limit}]`
+`{tariffs_endpoint_url}?[date_from={date_from}]&[date_to={date_to}]&[offset={offset}]&[limit={limit}]`
 
 Examples:
 
-`+https://www.server.com/ocpi/cpo/2.2/tariffs/?date_from=2019-01-28T12:00:00&amp;date_to=2019-01-29T12:00:00+`
+`+https://www.server.com/ocpi/cpo/2.2/tariffs/?date_from=2019-01-28T12:00:00&date_to=2019-01-29T12:00:00+`
 
 `+https://ocpi.server.com/2.2/tariffs/?offset=50+`
 
-`+https://www.server.com/ocpi/2.2/tariffs/?date_from=2019-01-29T12:00:00&amp;limit=100+`
+`+https://www.server.com/ocpi/2.2/tariffs/?date_from=2019-01-29T12:00:00&limit=100+`
 
-`+https://www.server.com/ocpi/cpo/2.2/tariffs/?offset=50&amp;limit=100+`
+`+https://www.server.com/ocpi/cpo/2.2/tariffs/?offset=50&limit=100+`
 
 
 [[mod_tariffs_cpo_get_request_parameters]]

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -135,7 +135,7 @@ Example:
 |POST |n/a 
 |<<mod_tariffs_put_method,PUT>> |Push new/updated Tariff object to the eMSP. 
 |PATCH|n/a
-|<<mod_tariffs_delete_method,DELETE>> |Remove a Tariff object which is no longer valid. 
+|<<mod_tariffs_delete_method,DELETE>> |Remove a Tariff object which is no longer in use and will not be used in future either. 
 |===
 
 [[mod_tariffs_msp_get_method]]
@@ -215,7 +215,9 @@ include::examples/tariff_put_example.json[]
 [[mod_tariffs_delete_method]]
 ===== *DELETE* Method
 
-Delete a no longer valid Tariff object.
+Delete a Tariff object which is not used any more and will not be used in future either.
+
+NOTE: Before deleting a Tariff object, it is RECOMMENDED to ensure that the Tariff object is not referenced by any <<mod_locations.asciidoc#mod_locations_connector_object,Connector object>> within the `tariff_ids` anymore.
 
 [[mod_tariffs_msp_delete_request_parameters]]
 ====== Request Parameters

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -585,13 +585,20 @@ include::examples/tariff_3_alt_url.json[]
 
 For a charging session on a Monday morning starting at 09:30 which takes 2.5 hours,
 where the driver uses a maximum of 16A of power and is parking for additional 45 minutes afterwards,
+For a charging session on a Monday morning starting at 09:30 which takes 2.45 hours,
+where the driver uses a maximum of 16A of power and is parking for additional 42 minutes afterwards,
 this tariff will result in costs of 8.75 euro (excl. VAT) or 10 euro (incl. VAT)
 for a total session time of 150 minutes (charging) + 45 minutes (parking).
+for a total session time of 147 minutes (charging) + 42 minutes (parking).
+Because charging is billed per 15 minutes, the driver has to pay for 150 minutes.
+Similarly, the driver has to pay for 45 minutes of parking as its billed per 5 minutes.
 
-For a charging session on a Saturday afternoon starting at 13:30 which takes 2 hours,
-where the driver uses a minimum of 43A of power and is parking for additional 75 minutes afterwards,
+For a charging session on a Saturday afternoon starting at 13:30 which takes 1.9 hours,
+where the driver uses a minimum of 43A of power and is parking for additional 71 minutes afterwards,
 this tariff will result in costs of 12.50 euro (excl. VAT) or 14,13 euro (incl. VAT)
-for a total session time of 120 minutes (charging) + 75 minutes (parking).
+for a total session time of 114 minutes (charging) + 71 minutes (parking).
+Because charging is billed per 10 minutes, the driver has to pay for 120 minutes.
+Similarly, the driver has to pay for 75 minutes of parking as its billed per 5 minutes.
 
 [source,json]
 ----


### PR DESCRIPTION
This PR only touches the `mod_tariffs.asciidoc` file and related examples. It improves the wording and spelling and unifies the styling of things.

A big part of this PR is also an extension of the tariff examples by an explanation of each example. It was sometimes difficult to understand the pricing logic, which makes this even more valuable in my opinion.

Please have a (thorough) look at this @RobertdeLeeuw-IHomer, @poohsen as there might be understanding issues in the examples.