### PR TITLE
Incorrect prices for tariff with reservation price

### DIFF
--- a/examples/tariff_15_reservation_5_euro_per_hour.json
+++ b/examples/tariff_15_reservation_5_euro_per_hour.json
@@ -6,7 +6,7 @@
   "elements": [{
     "price_components": [{
       "type": "TIME",
-      "price": 6.00,
+      "price": 5.00,
       "vat": 20.0,
       "step_size": 60
     }],

--- a/examples/tariff_16_reservation_2_euro_fee_5_euro_per_hour.json
+++ b/examples/tariff_16_reservation_2_euro_fee_5_euro_per_hour.json
@@ -11,7 +11,7 @@
       "step_size": 1
     }, {
       "type": "TIME",
-      "price": 6.00,
+      "price": 5.00,
       "vat": 20.0,
       "step_size": 300
     }],


### PR DESCRIPTION
The tariffs "tariff with reservation price" and "tariff with reservation price and fee" have a price of 5€ per hour but the examples have 6€.