### PR TITLE
Bug/contradictory versions

### DIFF
--- a/version_information_endpoint.asciidoc
+++ b/version_information_endpoint.asciidoc
@@ -42,7 +42,7 @@ Both, CPOs and eMSPs MUST implement such a version endpoint.
 
 [cols="2,1,10",options="header"]
 |===
-|Type |Card. |Description
+|Type |Card. |Description 
 
 |<<version_information_endpoint_version_class,Version>> |+ |A list of supported OCPI versions. 
 |===

--- a/version_information_endpoint.asciidoc
+++ b/version_information_endpoint.asciidoc
@@ -40,11 +40,11 @@ Both, CPOs and eMSPs MUST implement such a version endpoint.
 [[version_information_get_versions_endpoint_data]]
 ==== Data
 
-[cols="3,2,1,10",options="header"]
+[cols="2,1,10",options="header"]
 |===
-|Property |Type |Card. |Description 
+|Type |Card. |Description
 
-|versions |<<version_information_endpoint_version_class,Version>> |+ |A list of supported OCPI versions. 
+|<<version_information_endpoint_version_class,Version>> |+ |A list of supported OCPI versions. 
 |===
 
 [[version_information_endpoint_version_class]]

--- a/version_information_endpoint.md
+++ b/version_information_endpoint.md
@@ -23,9 +23,9 @@ Both the CPO and the eMSP must have this endpoint.
 
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
-| Property  | Type                       | Card.  | Description                               |
-|-----------|----------------------------|--------|-------------------------------------------|
-| versions  | [Version](#version-class)  | +      | A list of supported OCPI versions.        |
+| Type                       | Card.  | Description                               |
+|----------------------------|--------|-------------------------------------------|
+| [Version](#version-class)  | +      | A list of supported OCPI versions.        |
 <div><!-- ---------------------------------------------------------------------------- --></div>
 
 


### PR DESCRIPTION
Fixes 6.1.1 as per https://github.com/ocpi/ocpi/issues/245.

Removed the `Property` column from the 6.1.1. Data table in the Versions asciidoc. Also changed in the respective markdown file (not sure if this file is still necessary though). 