### PR TITLE
response_url purpose

### DIFF
--- a/mod_commands.asciidoc
+++ b/mod_commands.asciidoc
@@ -257,7 +257,7 @@ As there might be cost involved for a Reservation, canceling a reservation might
 |===
 |Property |Type |Card. |Description
 
-|response_url |<<types.asciidoc#types_url_type,URL>> |1 |URL that the CommandResponse POST should be send to. This URL might contain an unique ID to be able to distinguish between ReserveNow requests.
+|response_url |<<types.asciidoc#types_url_type,URL>> |1 |URL that the CommandResult POST should be send to. This URL might contain an unique ID to be able to distinguish between ReserveNow requests.
 |reservation_id |<<types.asciidoc#types_cistring_type,CiString>>(36) |1 |Reservation id, unique for this reservation. If the Charge Point already has a reservation that matches this reservationId the Charge Point will replace the reservation.
 |===
 


### PR DESCRIPTION
response_url is probably for use in CommandResult (2.2 asynchronous) instead of CommandResponse