### PR TITLE
Makes this example conform to OCPI v 2.2

### DIFF
--- a/examples/session_example_1_simple_start.json
+++ b/examples/session_example_1_simple_start.json
@@ -7,7 +7,7 @@
     "cdr_token": {
         "uid": "123abc",
         "type": "RFID",
-        "contract_id": "NL-TST-123-1"
+        "contract_id": "NL-TST-C12345678-S"
     },
     "auth_method": "WHITELIST",
     "location_id": "LOC1",

--- a/examples/session_example_1_simple_start.json
+++ b/examples/session_example_1_simple_start.json
@@ -1,19 +1,22 @@
 {
-  "country_code": "BE",
-  "party_id": "BEC",
-  "id": "101",
-  "start_date_time": "2015-06-29T22:39:09Z",
-  "kwh": 0.00,
-  "token_uid": "012345678",
-  "token_type": "RFID",
-  "auth_method": "WHITELIST",
-  "location_id": "LOC1",
-  "evse_uid": "3256",
-  "connector_id": "1",
-  "currency": "EUR",
-  "total_cost": {
-    "excl_vat": 2.50
-  },
-  "status": "PENDING",
-  "last_updated": "2015-06-29T22:39:09Z"
+    "country_code": "NL",
+    "party_id": "STK",
+    "id": "101",
+    "start_date_time": "2020-03-09T10:17:09Z",
+    "kwh": 0.0,
+    "cdr_token": {
+        "uid": "123abc",
+        "type": "RFID",
+        "contract_id": "NL-TST-123-1"
+    },
+    "auth_method": "WHITELIST",
+    "location_id": "LOC1",
+    "evse_uid": "3256",
+    "connector_id": "1",
+    "currency": "EUR",
+    "total_cost": {
+        "excl_vat": 2.5
+    },
+    "status": "PENDING",
+    "last_updated": "2020-03-09T10:17:09Z"
 }

--- a/examples/session_example_2_short_finished.json
+++ b/examples/session_example_2_short_finished.json
@@ -5,8 +5,11 @@
   "start_date_time": "2015-06-29T22:39:09Z",
   "end_date_time": "2015-06-29T23:50:16Z",
   "kwh": 41.00,
-  "token_uid": "012345678",
-  "token_type": "RFID",
+   "cdr_token": {
+        "uid": "123abc",
+        "type": "RFID",
+        "contract_id": "NL-TST-C12345678-S"
+    },
   "auth_method": "WHITELIST",
   "location_id": "LOC1",
   "evse_uid": "3256",


### PR DESCRIPTION
This file contained a mistake because it wasn't updated to the OCPI version 2.2 with a CdrToken object nested under the key `cdr_token` in the session JSON. 
This was proposed on Slack here: https://ocpi.slack.com/archives/C0S64NZJQ/p1583748925005100