### PR TITLE
Tariff should contain country_code and party_id

### DIFF
--- a/examples/cdr_example.json
+++ b/examples/cdr_example.json
@@ -30,6 +30,8 @@
   },
   "currency": "EUR",
   "tariffs": [{
+    "country_code": "BE",
+    "party_id": "BEC",
     "id": "12",
     "currency": "EUR",
     "elements": [{


### PR DESCRIPTION
Tariff inside the CDR example should contain the fields country_code and party_id to adhere to the spec.