### PR TITLE
Update Tokens Put Example. Fix #312

### DIFF
--- a/examples/token_put_example.json
+++ b/examples/token_put_example.json
@@ -1,5 +1,5 @@
 {
-  "country_code": "DE",
+  "country_code": "NL",
   "party_id": "TNM",
   "uid": "012345678",
   "type": "RFID",


### PR DESCRIPTION
This PR adjusts the `country_code` in the Tokens PUT Example so that it matches the `country_code` in the URL being used. This to comply with the spec's prescription that these two SHALL be the same value.