### PR TITLE
clarify use of base64 in HTTP auth header

### DIFF
--- a/credentials.asciidoc
+++ b/credentials.asciidoc
@@ -160,7 +160,7 @@ This method MUST return a `HTTP status code 405: method not allowed` if the clie
 |===
 |Property |Type |Card. |Description 
 
-|token |<<types.asciidoc#types_string_type,string>>(64) |1 |Case Sensitive, ASCII only. The credentials token for the other party to authenticate in your system. Not encoded in Base64 or any other encoding.
+|token |<<types.asciidoc#types_string_type,string>>(64) |1 |The credentials token for the other party to authenticate in your system. It should only contain printable non-whitespace ASCII characters, that is, characters with Unicode code points from the range of U+0021 up to and including U+007E.
 |url |<<types.asciidoc#types_url_type,URL>> |1 |The URL to your API versions endpoint. 
 |roles |<<credentials_credentials_role_class,CredentialsRole>> |+ |List of the roles this party provides.
 |===

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -22,7 +22,7 @@ Every OCPI HTTP request MUST add an 'Authorization' header. The header looks as 
 
 [source]
 ----
-  Authorization: Token IpbJOXxkxOAuKR92z0nEcmVF3Qw09VG7I7d/WCg0koM=
+  Authorization: Token ZWJmM2IzOTktNzc5Zi00NDk3LTliOWQtYWM2YWQzY2M0NGQyCg==
 ----
 
 NOTE: HTTP header names are case-insensitive
@@ -33,7 +33,7 @@ The literal 'Token' indicates that the token-based authentication mechanism is u
 These are different 'tokens' than the <<mod_tokens.asciidoc#mod_tokens_token_object,Tokens>> exchanged via the <<mod_tokens.asciidoc#mod_tokens_tokens_module,Token Module>>: Tokens used by drivers to authorize charging.
 To prevent confusion, when talking about the token used here in the HTTP Authorization header, call them: 'Credentials Tokens'.
 
-Its parameter is a string consisting of printable, non-whitespace ASCII characters. It contains the 'credentials token' Base64 encoded.
+After the literal 'Token', there SHALL be a space (U+0020), followed by the credentials token encoded with Base64 according to <<https://datatracker.ietf.org/doc/html/rfc4648#section-4,RFC 4648>>.
 
 The credentials token must uniquely identify the requesting party.
 This way, the server can use the information in the Authorization header to link the request to the correct requesting party's account.

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -33,7 +33,15 @@ The literal 'Token' indicates that the token-based authentication mechanism is u
 These are different 'tokens' than the <<mod_tokens.asciidoc#mod_tokens_token_object,Tokens>> exchanged via the <<mod_tokens.asciidoc#mod_tokens_tokens_module,Token Module>>: Tokens used by drivers to authorize charging.
 To prevent confusion, when talking about the token used here in the HTTP Authorization header, call them: 'Credentials Tokens'.
 
-After the literal 'Token', there SHALL be a space (U+0020), followed by the credentials token encoded with Base64 according to <<https://datatracker.ietf.org/doc/html/rfc4648#section-4,RFC 4648>>.
+After the literal 'Token', there SHALL be one space, followed by the 'encoded token'. The encoded token is obtained by encoding the credentials token to an octet sequence with UTF-8 and then encoding that octet sequence with Base64 according to https://datatracker.ietf.org/doc/html/rfc4648#section-4[RFC 4648].
+
+So for example, to use the credentials token 'example-token' in an OCPI request, one should include this header:
+
+[source]
+----
+  Authorization: Token ZXhhbXBsZS10b2tlbgo=
+----
+
 
 NOTE: Many OCPI 2.1.1 and 2.2 implementations do not Base64 encode the credentials token when including it in the 'Authorization' header. Since OCPI 2.2-d2 the OCPI specification documents clearly require Base64 encoding the credentials token in the header value. Implementations that wish to be compatible with non-encoding 2.1.1 and 2.2 implementations have to choose the right way to parse and write authorization headers by either trial and error or configuration flags.
 

--- a/transport_and_format.asciidoc
+++ b/transport_and_format.asciidoc
@@ -35,6 +35,8 @@ To prevent confusion, when talking about the token used here in the HTTP Authori
 
 After the literal 'Token', there SHALL be a space (U+0020), followed by the credentials token encoded with Base64 according to <<https://datatracker.ietf.org/doc/html/rfc4648#section-4,RFC 4648>>.
 
+NOTE: Many OCPI 2.1.1 and 2.2 implementations do not Base64 encode the credentials token when including it in the 'Authorization' header. Since OCPI 2.2-d2 the OCPI specification documents clearly require Base64 encoding the credentials token in the header value. Implementations that wish to be compatible with non-encoding 2.1.1 and 2.2 implementations have to choose the right way to parse and write authorization headers by either trial and error or configuration flags.
+
 The credentials token must uniquely identify the requesting party.
 This way, the server can use the information in the Authorization header to link the request to the correct requesting party's account.
 


### PR DESCRIPTION
We saw some confusion on Slack regarding the use of base64 encoding in the `Authorization` header of OCPI requests. This relates to earlier confusion expressed in #212 . This pull request aims to make the specification completely clear and consistent about this.