### PR TITLE
Added use case for failed authorization

### DIFF
--- a/B_use_cases/uc_authorization.asciidoc
+++ b/B_use_cases/uc_authorization.asciidoc
@@ -76,3 +76,12 @@ Charge Point request authorization for an RFID that the CPO does not know, not i
 
 
 
+[[uc_authorization_using_realtime_authorization_display_reason]]
+:UC_NR: 08
+:UC_TITLE: As a driver I want to know why my token is not authorized
+=== UC: {UC_NR} - {UC_TITLE}
+
+TODO:
+When MSP responds to real time authorization with something else than "ALLOWED", 
+show the specific reason to the driver on the display of the charge point. Use the language chosen by the driver in the MSP app or web application.
+


### PR DESCRIPTION
This is a specific use case where driver needs to act in order to restore validity of the token, for example, when there's no prepaid credit left. We should also tell the user what is wrong in a language they understand. This requires a charge point with a display or a push message from the MSP app. 

The use case could be numbered in a way that indicates it's not a core requirement. (I'm working on this topic currently in my implementation of OCPI 2.2 and it's quite tricky)