### PR TITLE
Changed power to current for amperes

### DIFF
--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -618,14 +618,14 @@ include::examples/tariff_3_alt_url.json[]
 *** Billed per 5 min (300 seconds)
 
 For a charging session on a Monday morning starting at 09:30 which takes 2:45 hours (165 minutes),
-where the driver uses a maximum of 16A of power and is parking for additional 42 minutes afterwards,
+where the driver uses a maximum of 16A of current and is parking for additional 42 minutes afterwards,
 this tariff will result in costs of 9.00 euro (excl. VAT) or 10.30 euro (incl. VAT)
 for a total session time of 147 minutes (charging) + 42 minutes (parking).
 As the tariff switches from a `TIME` based tariff to `PARKING_TIME`, `step_size` is not used on the charging time, only on the parking time.
 The driver has to pay for 165 minutes charging (2.75 euro excl. VAT) and 45 minutes of parking, as parking is billed per 5 minutes (3.75 euro excl. VAT).
 
 For a charging session on a Saturday afternoon starting at 13:30 which takes 1:54 hours (114 minutes),
-where the driver uses a minimum of 43A of power (all the time, which is only theoretically possible) and is parking for additional 71 minutes afterwards,
+where the driver uses a minimum of 43A of current (all the time, which is only theoretically possible) and is parking for additional 71 minutes afterwards,
 this tariff will result in a total cost of 12.375 euro (excl. VAT) or 13.975 euro (incl. VAT).
 Total charging time of 114 minutes (2.375 euro excl. VAT). Parking time: 71 minutes due to `step_size` rounded to 75 minutes (7.50 euro excl VAT).
 


### PR DESCRIPTION
Tariff example uses ampere for power instead of current