### PR TITLE
Fix level of Roles in Types

### DIFF
--- a/types.asciidoc
+++ b/types.asciidoc
@@ -68,7 +68,7 @@ Unless mentioned otherwise, numbers use 4 decimals and a _sufficiently large amo
 |===
 
 [[types_role_enum]]
-==== Role _enum_
+=== Role _enum_
 
 [cols="3,10",options="header"]
 |===


### PR DESCRIPTION
Currently, the type role looks like a sub-element of price, which at least for me looks pretty wrong; it should be a level up, so is not a child of Price class.

Currently:
* 16.5. Price class
* 16.5.1. Role enum
...

In my opinion, it should be:
* 16.5. Price class
* 16.6. Role enum
...