### PR TITLE
Add time zone to CDR Location

### DIFF
--- a/C_transport_modules/mod_cdrs.asciidoc
+++ b/C_transport_modules/mod_cdrs.asciidoc
@@ -408,6 +408,8 @@ The _CdrLocation_ class contains only the relevant information from the <<mod_lo
 |connector_standard |<<mod_locations.asciidoc#mod_locations_connectortype_enum,ConnectorType>> |1 |The standard of the installed connector.
 |connector_format |<<mod_locations.asciidoc#mod_locations_connectorformat_enum,ConnectorFormat>> |1 |The format (socket/cable) of the installed connector.
 |connector_power_type |<<mod_locations.asciidoc#mod_locations_powertype_enum,PowerType>> |1 |
+|time_zone |<<types.asciidoc#types_string_type,string>>(255) |? |One of IANA tzdata's TZ-values representing the time zone of the location. Examples: "Europe/Oslo", "Europe/Zurich". (http://www.iana.org/time-zones[http://www.iana.org/time-zones]) 
+
 |===
 
 


### PR DESCRIPTION
As described in https://github.com/ocpi/ocpi/issues/517

The time zone of the charging location is necessary in order to correctly calculate the costs when a tariff contains time or date restrictions.