### PR TITLE
Clarify overlapping tariff restrictions pricing

### DIFF
--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -251,8 +251,6 @@ This system of Tariffs, Tariff Elements and Price Components can be used to crea
 
 When the list of Tariff Elements contains more than one Element that has a Price Component for a certain dimension, then the first Tariff Element with a Price Component for that dimension in the list with matching Tariff Restrictions will be used. Only one Price Component per dimension can be active at any point in time, but multiple Price Components for different dimensions can be active at once. That is you can have an ENERGY component and a TIME component active at the same time, but only those ones that are in the first Tariff Element that has a Price Component for that dimension and that has restrictions that match at that time.
 
-A consumed quantity of a given dimension is priced only once. If two Tariff Elements have overlapping restrictions, the subsequent Tariff Element will only be used to price quantities that have not already been priced by a previous Tariff Element.
-
 When no Tariff Element with a specific Dimension is found for which the Restrictions match,
 and there is no Tariff Element in the list with the given Dimension without Restrictions,
 there will be no costs for that Tariff Dimension.
@@ -1119,7 +1117,7 @@ Can also be used in combination with a <<mod_tariffs_tariffrestrictions_class,RE
 
  A `TariffRestrictions` object describes if and when a Tariff Element becomes active or inactive during a Charging Session.
 
-These restrictions are not to be interpreted as making the Tariff Element applicable or not applicable for the entire Charging Session.
+These restrictions are not to be interpreted as making the Tariff Element applicable or not applicable for the entire Charging Session, nor as causing a consumed quantity to be priced more than once for the same dimension.
 
 When more than one restriction is set, they are to be treated as a logical AND. So a Tariff Element is active if and only if all of the properties in its `TariffRestrictions` match.
 

--- a/mod_tariffs.asciidoc
+++ b/mod_tariffs.asciidoc
@@ -251,6 +251,8 @@ This system of Tariffs, Tariff Elements and Price Components can be used to crea
 
 When the list of Tariff Elements contains more than one Element that has a Price Component for a certain dimension, then the first Tariff Element with a Price Component for that dimension in the list with matching Tariff Restrictions will be used. Only one Price Component per dimension can be active at any point in time, but multiple Price Components for different dimensions can be active at once. That is you can have an ENERGY component and a TIME component active at the same time, but only those ones that are in the first Tariff Element that has a Price Component for that dimension and that has restrictions that match at that time.
 
+A consumed quantity of a given dimension is priced only once. If two Tariff Elements have overlapping restrictions, the subsequent Tariff Element will only be used to price quantities that have not already been priced by a previous Tariff Element.
+
 When no Tariff Element with a specific Dimension is found for which the Restrictions match,
 and there is no Tariff Element in the list with the given Dimension without Restrictions,
 there will be no costs for that Tariff Dimension.


### PR DESCRIPTION
Clarify that overlapping tariff restrictions do not result in double pricing. 

A consumed quantity of a given dimension is priced only once, and subsequent Tariff Elements with overlapping restrictions will only price quantities that have not already been priced.