### PR TITLE
Update location_example.json to have the same floor for both EVSEs

### DIFF
--- a/examples/location_example.json
+++ b/examples/location_example.json
@@ -62,7 +62,7 @@
     }],
     "parking": ["2", "3"],
     "physical_reference": "2",
-    "floor_level": "-2",
+    "floor_level": "-1",
     "last_updated": "2015-06-29T20:39:09Z"
   }],
   "parking_places": [{


### PR DESCRIPTION
In this example, the two EVSEs are clearly next to each other (as the first is between parking spots 1 and 2, and the second is between parking spots 2 and 3). Therefore, it is inconsistent and may cause incomprehension to mark them as "on different floors" with a different floor_level property.